### PR TITLE
feat(auth): sign in with email and password

### DIFF
--- a/api/migrations/001_create_users.sql
+++ b/api/migrations/001_create_users.sql
@@ -9,6 +9,8 @@ CREATE TABLE users (
     email_verified_at   TIMESTAMPTZ,
     plan                TEXT NOT NULL DEFAULT 'free'
                             CHECK (plan IN ('free', 'premium')),
+    failed_attempts     INTEGER NOT NULL DEFAULT 0,
+    locked_until        TIMESTAMPTZ,
     created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     deleted_at          TIMESTAMPTZ

--- a/api/src/domain/entities/user.rs
+++ b/api/src/domain/entities/user.rs
@@ -45,6 +45,8 @@ pub struct User {
     pub avatar_url: Option<String>,
     pub email_verified_at: Option<DateTime<Utc>>,
     pub plan: Plan,
+    pub failed_attempts: i32,
+    pub locked_until: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/api/src/domain/ports/inbound/auth_service.rs
+++ b/api/src/domain/ports/inbound/auth_service.rs
@@ -8,6 +8,11 @@ pub struct RegisterCommand {
     pub full_name: String,
 }
 
+pub struct LoginCommand {
+    pub email: String,
+    pub password: String,
+}
+
 #[derive(Debug)]
 pub struct AuthResult {
     pub token: String,
@@ -17,4 +22,5 @@ pub struct AuthResult {
 #[async_trait]
 pub trait AuthServicePort: Send + Sync {
     async fn register(&self, cmd: RegisterCommand) -> Result<AuthResult, AppError>;
+    async fn login(&self, cmd: LoginCommand) -> Result<AuthResult, AppError>;
 }

--- a/api/src/domain/ports/outbound/user_repository.rs
+++ b/api/src/domain/ports/outbound/user_repository.rs
@@ -1,9 +1,17 @@
 use crate::domain::entities::user::User;
 use crate::errors::AppError;
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
 
 #[async_trait]
 pub trait UserRepository: Send + Sync {
     async fn find_by_email(&self, email: &str) -> Result<Option<User>, AppError>;
     async fn create(&self, user: User) -> Result<User, AppError>;
+    /// Atomically increments failed_attempts and returns the new count.
+    async fn record_failed_attempt(&self, user_id: Uuid) -> Result<i32, AppError>;
+    /// Sets locked_until; the Postgres adapter will also reset failed_attempts to 0.
+    async fn lock_until(&self, user_id: Uuid, until: DateTime<Utc>) -> Result<(), AppError>;
+    /// Resets failed_attempts to 0 and clears locked_until on successful login.
+    async fn reset_failed_attempts(&self, user_id: Uuid) -> Result<(), AppError>;
 }

--- a/api/src/domain/ports/outbound/user_repository.rs
+++ b/api/src/domain/ports/outbound/user_repository.rs
@@ -4,14 +4,31 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
+/// Result of a single atomic failed-login attempt.
+pub enum FailedLoginOutcome {
+    /// Account is not locked yet; `attempts` is the new running total.
+    Incremented { attempts: i32 },
+    /// Threshold was reached; account is now locked until this timestamp.
+    Locked { until: DateTime<Utc> },
+}
+
 #[async_trait]
 pub trait UserRepository: Send + Sync {
     async fn find_by_email(&self, email: &str) -> Result<Option<User>, AppError>;
     async fn create(&self, user: User) -> Result<User, AppError>;
-    /// Atomically increments failed_attempts and returns the new count.
-    async fn record_failed_attempt(&self, user_id: Uuid) -> Result<i32, AppError>;
-    /// Sets locked_until; the Postgres adapter will also reset failed_attempts to 0.
-    async fn lock_until(&self, user_id: Uuid, until: DateTime<Utc>) -> Result<(), AppError>;
+
+    /// Atomically increments failed_attempts.
+    /// If the new count >= `max_attempts`, sets `locked_until` in the same
+    /// operation and returns `Locked`. The Postgres adapter must implement
+    /// this as a single UPDATE so there is no window between the increment
+    /// and the lock write.
+    async fn record_failed_attempt(
+        &self,
+        user_id: Uuid,
+        max_attempts: i32,
+        lock_until: DateTime<Utc>,
+    ) -> Result<FailedLoginOutcome, AppError>;
+
     /// Resets failed_attempts to 0 and clears locked_until on successful login.
     async fn reset_failed_attempts(&self, user_id: Uuid) -> Result<(), AppError>;
 }

--- a/api/src/domain/services/auth_service.rs
+++ b/api/src/domain/services/auth_service.rs
@@ -12,7 +12,7 @@ use crate::domain::entities::user::{Plan, User};
 use crate::domain::ports::inbound::auth_service::{
     AuthResult, AuthServicePort, LoginCommand, RegisterCommand,
 };
-use crate::domain::ports::outbound::user_repository::UserRepository;
+use crate::domain::ports::outbound::user_repository::{FailedLoginOutcome, UserRepository};
 use crate::errors::AppError;
 
 const MAX_FAILED_ATTEMPTS: i32 = 5;
@@ -158,16 +158,18 @@ impl<U: UserRepository> AuthServicePort for AuthService<U> {
             .ok_or(AppError::Unauthorized)?;
 
         if !Self::verify_password(&cmd.password, hash) {
-            let attempts = self.user_repo.record_failed_attempt(user.id).await?;
-            if attempts >= MAX_FAILED_ATTEMPTS {
-                let unlock_at = Utc::now() + Duration::minutes(LOCKOUT_MINUTES);
-                self.user_repo.lock_until(user.id, unlock_at).await?;
-                return Err(AppError::TooManyRequests(format!(
+            let lock_at = Utc::now() + Duration::minutes(LOCKOUT_MINUTES);
+            let outcome = self
+                .user_repo
+                .record_failed_attempt(user.id, MAX_FAILED_ATTEMPTS, lock_at)
+                .await?;
+            return match outcome {
+                FailedLoginOutcome::Locked { until } => Err(AppError::TooManyRequests(format!(
                     "Account locked until {}",
-                    unlock_at.format("%H:%M UTC")
-                )));
-            }
-            return Err(AppError::Unauthorized);
+                    until.format("%H:%M UTC")
+                ))),
+                FailedLoginOutcome::Incremented { .. } => Err(AppError::Unauthorized),
+            };
         }
 
         self.user_repo.reset_failed_attempts(user.id).await?;

--- a/api/src/domain/services/auth_service.rs
+++ b/api/src/domain/services/auth_service.rs
@@ -1,6 +1,6 @@
 use argon2::{
-    password_hash::{rand_core::OsRng, SaltString},
-    Argon2, PasswordHasher,
+    password_hash::{rand_core::OsRng, PasswordVerifier, SaltString},
+    Argon2, PasswordHash, PasswordHasher,
 };
 use async_trait::async_trait;
 use chrono::{Duration, Utc};
@@ -9,9 +9,14 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::domain::entities::user::{Plan, User};
-use crate::domain::ports::inbound::auth_service::{AuthResult, AuthServicePort, RegisterCommand};
+use crate::domain::ports::inbound::auth_service::{
+    AuthResult, AuthServicePort, LoginCommand, RegisterCommand,
+};
 use crate::domain::ports::outbound::user_repository::UserRepository;
 use crate::errors::AppError;
+
+const MAX_FAILED_ATTEMPTS: i32 = 5;
+const LOCKOUT_MINUTES: i64 = 15;
 
 #[derive(Serialize, Deserialize)]
 struct Claims {
@@ -65,6 +70,16 @@ impl<U: UserRepository> AuthService<U> {
             .map_err(|e| AppError::Internal(anyhow::anyhow!("Password hashing failed: {}", e)))
     }
 
+    fn verify_password(password: &str, hash: &str) -> bool {
+        PasswordHash::new(hash)
+            .map(|parsed| {
+                Argon2::default()
+                    .verify_password(password.as_bytes(), &parsed)
+                    .is_ok()
+            })
+            .unwrap_or(false)
+    }
+
     fn issue_jwt(&self, user_id: Uuid) -> Result<String, AppError> {
         let expiry_hours = i64::try_from(self.jwt_expiry_hours)
             .map_err(|_| AppError::Internal(anyhow::anyhow!("JWT expiry hours overflow")))?;
@@ -102,11 +117,60 @@ impl<U: UserRepository> AuthServicePort for AuthService<U> {
             avatar_url: None,
             email_verified_at: None,
             plan: Plan::Free,
+            failed_attempts: 0,
+            locked_until: None,
             created_at: now,
             updated_at: now,
         };
 
         let user = self.user_repo.create(user).await?;
+        let token = self.issue_jwt(user.id)?;
+
+        Ok(AuthResult {
+            token,
+            user_id: user.id,
+        })
+    }
+
+    async fn login(&self, cmd: LoginCommand) -> Result<AuthResult, AppError> {
+        let email = cmd.email.trim().to_lowercase();
+
+        // Use a generic error for both "not found" and "wrong password" to prevent enumeration
+        let user = self
+            .user_repo
+            .find_by_email(&email)
+            .await?
+            .ok_or(AppError::Unauthorized)?;
+
+        // Check lockout before verifying password
+        if let Some(locked_until) = user.locked_until {
+            if locked_until > Utc::now() {
+                return Err(AppError::TooManyRequests(format!(
+                    "Account locked until {}",
+                    locked_until.format("%H:%M UTC")
+                )));
+            }
+        }
+
+        let hash = user
+            .password_hash
+            .as_deref()
+            .ok_or(AppError::Unauthorized)?;
+
+        if !Self::verify_password(&cmd.password, hash) {
+            let attempts = self.user_repo.record_failed_attempt(user.id).await?;
+            if attempts >= MAX_FAILED_ATTEMPTS {
+                let unlock_at = Utc::now() + Duration::minutes(LOCKOUT_MINUTES);
+                self.user_repo.lock_until(user.id, unlock_at).await?;
+                return Err(AppError::TooManyRequests(format!(
+                    "Account locked until {}",
+                    unlock_at.format("%H:%M UTC")
+                )));
+            }
+            return Err(AppError::Unauthorized);
+        }
+
+        self.user_repo.reset_failed_attempts(user.id).await?;
         let token = self.issue_jwt(user.id)?;
 
         Ok(AuthResult {

--- a/api/src/errors.rs
+++ b/api/src/errors.rs
@@ -26,6 +26,9 @@ pub enum AppError {
     #[error("Conflict: {0}")]
     Conflict(String),
 
+    #[error("Too many requests: {0}")]
+    TooManyRequests(String),
+
     #[error("Database error: {0}")]
     Database(#[from] sqlx::Error),
 
@@ -42,6 +45,7 @@ impl IntoResponse for AppError {
             AppError::Validation(msg) => (StatusCode::UNPROCESSABLE_ENTITY, msg.clone()),
             AppError::PlanLimitReached(msg) => (StatusCode::PAYMENT_REQUIRED, msg.clone()),
             AppError::Conflict(msg) => (StatusCode::CONFLICT, msg.clone()),
+            AppError::TooManyRequests(msg) => (StatusCode::TOO_MANY_REQUESTS, msg.clone()),
             AppError::Database(e) => {
                 tracing::error!("Database error: {:?}", e);
                 (

--- a/api/tests/unit.rs
+++ b/api/tests/unit.rs
@@ -1,2 +1,5 @@
 #[path = "unit/services/auth_service_test.rs"]
 mod auth_service_test;
+
+#[path = "unit/services/auth_service_login_test.rs"]
+mod auth_service_login_test;

--- a/api/tests/unit/services/auth_service_login_test.rs
+++ b/api/tests/unit/services/auth_service_login_test.rs
@@ -131,7 +131,7 @@ fn make_service(repo: InMemoryUserRepository) -> AuthService<InMemoryUserReposit
     AuthService::new(repo, JWT_SECRET.to_string(), 168_u64)
 }
 
-/// Builds a User with a known argon2 hash for "password1".
+/// Builds a User with an argon2 hash for the provided password.
 fn user_with_password(password: &str) -> User {
     use argon2::{
         password_hash::{rand_core::OsRng, SaltString},

--- a/api/tests/unit/services/auth_service_login_test.rs
+++ b/api/tests/unit/services/auth_service_login_test.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
@@ -42,6 +42,15 @@ impl InMemoryUserRepository {
         Self {
             rows: Mutex::new(map),
         }
+    }
+
+    fn failed_attempts_for(&self, email: &str) -> i32 {
+        self.rows
+            .lock()
+            .unwrap()
+            .get(email)
+            .map(|r| r.failed_attempts)
+            .unwrap_or(0)
     }
 
     fn with_locked_user(user: User, locked_until: DateTime<Utc>) -> Self {
@@ -122,6 +131,34 @@ impl UserRepository for InMemoryUserRepository {
         row.failed_attempts = 0;
         row.locked_until = None;
         Ok(())
+    }
+}
+
+// Newtype wrapper around Arc — lets a test retain a reference to inspect state
+// after the service has consumed the repo (orphan rules forbid direct
+// `impl UserRepository for Arc<InMemoryUserRepository>`).
+struct SharedRepo(Arc<InMemoryUserRepository>);
+
+#[async_trait]
+impl UserRepository for SharedRepo {
+    async fn find_by_email(&self, email: &str) -> Result<Option<User>, AppError> {
+        self.0.find_by_email(email).await
+    }
+    async fn create(&self, user: User) -> Result<User, AppError> {
+        self.0.create(user).await
+    }
+    async fn record_failed_attempt(
+        &self,
+        user_id: Uuid,
+        max_attempts: i32,
+        lock_until: DateTime<Utc>,
+    ) -> Result<FailedLoginOutcome, AppError> {
+        self.0
+            .record_failed_attempt(user_id, max_attempts, lock_until)
+            .await
+    }
+    async fn reset_failed_attempts(&self, user_id: Uuid) -> Result<(), AppError> {
+        self.0.reset_failed_attempts(user_id).await
     }
 }
 
@@ -225,16 +262,21 @@ async fn login_with_locked_account_returns_too_many_requests() {
 #[tokio::test]
 async fn login_wrong_password_increments_failed_attempts() {
     let user = user_with_password("password1");
-    let repo = InMemoryUserRepository::with_user(user);
-    let service = make_service(repo);
+    let repo = Arc::new(InMemoryUserRepository::with_user(user));
+    let service = AuthService::new(
+        SharedRepo(Arc::clone(&repo)),
+        JWT_SECRET.to_string(),
+        168_u64,
+    );
 
-    // Two failed attempts
     let _ = service.login(login_cmd("john@example.com", "wrong")).await;
-    let _ = service.login(login_cmd("john@example.com", "wrong")).await;
+    assert_eq!(repo.failed_attempts_for("john@example.com"), 1);
 
-    // 3rd attempt still returns Unauthorized (not locked yet)
-    let result = service.login(login_cmd("john@example.com", "wrong")).await;
-    assert!(matches!(result, Err(AppError::Unauthorized)));
+    let _ = service.login(login_cmd("john@example.com", "wrong")).await;
+    assert_eq!(repo.failed_attempts_for("john@example.com"), 2);
+
+    let _ = service.login(login_cmd("john@example.com", "wrong")).await;
+    assert_eq!(repo.failed_attempts_for("john@example.com"), 3);
 }
 
 #[tokio::test]

--- a/api/tests/unit/services/auth_service_login_test.rs
+++ b/api/tests/unit/services/auth_service_login_test.rs
@@ -1,0 +1,275 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, Utc};
+use uuid::Uuid;
+
+use done_with_debt_api::domain::{
+    entities::user::{Plan, User},
+    ports::{
+        inbound::auth_service::{AuthServicePort, LoginCommand},
+        outbound::user_repository::UserRepository,
+    },
+    services::auth_service::AuthService,
+};
+use done_with_debt_api::errors::AppError;
+
+// ── In-memory mock repository ─────────────────────────────────────────────────
+
+struct UserRow {
+    user: User,
+    failed_attempts: i32,
+    locked_until: Option<DateTime<Utc>>,
+}
+
+struct InMemoryUserRepository {
+    rows: Mutex<HashMap<String, UserRow>>, // keyed by email
+}
+
+impl InMemoryUserRepository {
+    fn with_user(user: User) -> Self {
+        let mut map = HashMap::new();
+        let email = user.email.clone();
+        map.insert(
+            email,
+            UserRow {
+                user,
+                failed_attempts: 0,
+                locked_until: None,
+            },
+        );
+        Self {
+            rows: Mutex::new(map),
+        }
+    }
+
+    fn with_locked_user(user: User, locked_until: DateTime<Utc>) -> Self {
+        let mut map = HashMap::new();
+        let email = user.email.clone();
+        map.insert(
+            email,
+            UserRow {
+                user,
+                failed_attempts: 5,
+                locked_until: Some(locked_until),
+            },
+        );
+        Self {
+            rows: Mutex::new(map),
+        }
+    }
+}
+
+#[async_trait]
+impl UserRepository for InMemoryUserRepository {
+    async fn find_by_email(&self, email: &str) -> Result<Option<User>, AppError> {
+        let rows = self.rows.lock().unwrap();
+        Ok(rows.get(email).map(|row| {
+            let mut u = row.user.clone();
+            u.failed_attempts = row.failed_attempts;
+            u.locked_until = row.locked_until;
+            u
+        }))
+    }
+
+    async fn create(&self, user: User) -> Result<User, AppError> {
+        let mut rows = self.rows.lock().unwrap();
+        if rows.contains_key(&user.email) {
+            return Err(AppError::Conflict("Email already in use".to_string()));
+        }
+        let email = user.email.clone();
+        rows.insert(
+            email,
+            UserRow {
+                user: user.clone(),
+                failed_attempts: 0,
+                locked_until: None,
+            },
+        );
+        Ok(user)
+    }
+
+    async fn record_failed_attempt(&self, user_id: Uuid) -> Result<i32, AppError> {
+        let mut rows = self.rows.lock().unwrap();
+        let row = rows
+            .values_mut()
+            .find(|r| r.user.id == user_id)
+            .ok_or_else(|| AppError::NotFound("User not found".to_string()))?;
+        row.failed_attempts += 1;
+        Ok(row.failed_attempts)
+    }
+
+    async fn lock_until(&self, user_id: Uuid, until: DateTime<Utc>) -> Result<(), AppError> {
+        let mut rows = self.rows.lock().unwrap();
+        let row = rows
+            .values_mut()
+            .find(|r| r.user.id == user_id)
+            .ok_or_else(|| AppError::NotFound("User not found".to_string()))?;
+        row.locked_until = Some(until);
+        row.failed_attempts = 0;
+        Ok(())
+    }
+
+    async fn reset_failed_attempts(&self, user_id: Uuid) -> Result<(), AppError> {
+        let mut rows = self.rows.lock().unwrap();
+        let row = rows
+            .values_mut()
+            .find(|r| r.user.id == user_id)
+            .ok_or_else(|| AppError::NotFound("User not found".to_string()))?;
+        row.failed_attempts = 0;
+        row.locked_until = None;
+        Ok(())
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const JWT_SECRET: &str = "test_secret_key_32_chars_minimum!";
+
+fn make_service(repo: InMemoryUserRepository) -> AuthService<InMemoryUserRepository> {
+    AuthService::new(repo, JWT_SECRET.to_string(), 168_u64)
+}
+
+/// Builds a User with a known argon2 hash for "password1".
+fn user_with_password(password: &str) -> User {
+    use argon2::{
+        password_hash::{rand_core::OsRng, SaltString},
+        Argon2, PasswordHasher,
+    };
+    let salt = SaltString::generate(&mut OsRng);
+    let hash = Argon2::default()
+        .hash_password(password.as_bytes(), &salt)
+        .unwrap()
+        .to_string();
+
+    User {
+        id: Uuid::new_v4(),
+        email: "john@example.com".to_string(),
+        password_hash: Some(hash),
+        full_name: "John Doe".to_string(),
+        avatar_url: None,
+        email_verified_at: None,
+        plan: Plan::Free,
+        failed_attempts: 0,
+        locked_until: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
+
+fn login_cmd(email: &str, password: &str) -> LoginCommand {
+    LoginCommand {
+        email: email.to_string(),
+        password: password.to_string(),
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn login_with_valid_credentials_returns_token() {
+    let user = user_with_password("password1");
+    let service = make_service(InMemoryUserRepository::with_user(user));
+
+    let result = service
+        .login(login_cmd("john@example.com", "password1"))
+        .await;
+
+    assert!(result.is_ok(), "expected Ok, got {:?}", result);
+    let auth = result.unwrap();
+    assert!(!auth.token.is_empty());
+    assert!(auth.user_id != Uuid::nil());
+}
+
+#[tokio::test]
+async fn login_with_wrong_password_returns_unauthorized() {
+    let user = user_with_password("password1");
+    let service = make_service(InMemoryUserRepository::with_user(user));
+
+    let result = service
+        .login(login_cmd("john@example.com", "wrongpassword"))
+        .await;
+
+    assert!(matches!(result, Err(AppError::Unauthorized)));
+}
+
+#[tokio::test]
+async fn login_with_nonexistent_email_returns_same_error_as_wrong_password() {
+    let user = user_with_password("password1");
+    let service = make_service(InMemoryUserRepository::with_user(user));
+
+    let result = service
+        .login(login_cmd("nobody@example.com", "password1"))
+        .await;
+
+    // Must be Unauthorized — not NotFound — to prevent email enumeration
+    assert!(matches!(result, Err(AppError::Unauthorized)));
+}
+
+#[tokio::test]
+async fn login_with_locked_account_returns_too_many_requests() {
+    let user = user_with_password("password1");
+    let locked_until = Utc::now() + Duration::minutes(10);
+    let service = make_service(InMemoryUserRepository::with_locked_user(user, locked_until));
+
+    let result = service
+        .login(login_cmd("john@example.com", "password1"))
+        .await;
+
+    assert!(matches!(result, Err(AppError::TooManyRequests(_))));
+}
+
+#[tokio::test]
+async fn login_wrong_password_increments_failed_attempts() {
+    let user = user_with_password("password1");
+    let repo = InMemoryUserRepository::with_user(user);
+    let service = make_service(repo);
+
+    // Two failed attempts
+    let _ = service.login(login_cmd("john@example.com", "wrong")).await;
+    let _ = service.login(login_cmd("john@example.com", "wrong")).await;
+
+    // 3rd attempt still returns Unauthorized (not locked yet)
+    let result = service.login(login_cmd("john@example.com", "wrong")).await;
+    assert!(matches!(result, Err(AppError::Unauthorized)));
+}
+
+#[tokio::test]
+async fn login_locks_account_after_5_failed_attempts() {
+    let user = user_with_password("password1");
+    let service = make_service(InMemoryUserRepository::with_user(user));
+
+    // 5 failed attempts
+    for _ in 0..5 {
+        let _ = service.login(login_cmd("john@example.com", "wrong")).await;
+    }
+
+    // 6th attempt (with correct password) must be locked
+    let result = service
+        .login(login_cmd("john@example.com", "password1"))
+        .await;
+    assert!(matches!(result, Err(AppError::TooManyRequests(_))));
+}
+
+#[tokio::test]
+async fn login_resets_failed_attempts_on_success() {
+    let user = user_with_password("password1");
+    let service = make_service(InMemoryUserRepository::with_user(user));
+
+    // 3 failed attempts then a success
+    for _ in 0..3 {
+        let _ = service.login(login_cmd("john@example.com", "wrong")).await;
+    }
+    let _ = service
+        .login(login_cmd("john@example.com", "password1"))
+        .await;
+
+    // Should be able to fail 4 more times without being locked (counter was reset)
+    for _ in 0..4 {
+        let _ = service.login(login_cmd("john@example.com", "wrong")).await;
+    }
+    let result = service.login(login_cmd("john@example.com", "wrong")).await;
+    // 5th attempt after reset — should lock now
+    assert!(matches!(result, Err(AppError::TooManyRequests(_))));
+}

--- a/api/tests/unit/services/auth_service_login_test.rs
+++ b/api/tests/unit/services/auth_service_login_test.rs
@@ -9,7 +9,7 @@ use done_with_debt_api::domain::{
     entities::user::{Plan, User},
     ports::{
         inbound::auth_service::{AuthServicePort, LoginCommand},
-        outbound::user_repository::UserRepository,
+        outbound::user_repository::{FailedLoginOutcome, UserRepository},
     },
     services::auth_service::AuthService,
 };
@@ -90,25 +90,27 @@ impl UserRepository for InMemoryUserRepository {
         Ok(user)
     }
 
-    async fn record_failed_attempt(&self, user_id: Uuid) -> Result<i32, AppError> {
+    async fn record_failed_attempt(
+        &self,
+        user_id: Uuid,
+        max_attempts: i32,
+        lock_until: DateTime<Utc>,
+    ) -> Result<FailedLoginOutcome, AppError> {
         let mut rows = self.rows.lock().unwrap();
         let row = rows
             .values_mut()
             .find(|r| r.user.id == user_id)
             .ok_or_else(|| AppError::NotFound("User not found".to_string()))?;
         row.failed_attempts += 1;
-        Ok(row.failed_attempts)
-    }
-
-    async fn lock_until(&self, user_id: Uuid, until: DateTime<Utc>) -> Result<(), AppError> {
-        let mut rows = self.rows.lock().unwrap();
-        let row = rows
-            .values_mut()
-            .find(|r| r.user.id == user_id)
-            .ok_or_else(|| AppError::NotFound("User not found".to_string()))?;
-        row.locked_until = Some(until);
-        row.failed_attempts = 0;
-        Ok(())
+        if row.failed_attempts >= max_attempts {
+            row.locked_until = Some(lock_until);
+            row.failed_attempts = 0;
+            Ok(FailedLoginOutcome::Locked { until: lock_until })
+        } else {
+            Ok(FailedLoginOutcome::Incremented {
+                attempts: row.failed_attempts,
+            })
+        }
     }
 
     async fn reset_failed_attempts(&self, user_id: Uuid) -> Result<(), AppError> {

--- a/api/tests/unit/services/auth_service_test.rs
+++ b/api/tests/unit/services/auth_service_test.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
 use done_with_debt_api::domain::{
@@ -51,6 +52,38 @@ impl UserRepository for InMemoryUserRepository {
         users.insert(user.email.clone(), user.clone());
         Ok(user)
     }
+
+    async fn record_failed_attempt(&self, user_id: Uuid) -> Result<i32, AppError> {
+        let mut users = self.users.lock().unwrap();
+        let user = users
+            .values_mut()
+            .find(|u| u.id == user_id)
+            .ok_or_else(|| AppError::NotFound("User not found".to_string()))?;
+        user.failed_attempts += 1;
+        Ok(user.failed_attempts)
+    }
+
+    async fn lock_until(&self, user_id: Uuid, until: DateTime<Utc>) -> Result<(), AppError> {
+        let mut users = self.users.lock().unwrap();
+        let user = users
+            .values_mut()
+            .find(|u| u.id == user_id)
+            .ok_or_else(|| AppError::NotFound("User not found".to_string()))?;
+        user.locked_until = Some(until);
+        user.failed_attempts = 0;
+        Ok(())
+    }
+
+    async fn reset_failed_attempts(&self, user_id: Uuid) -> Result<(), AppError> {
+        let mut users = self.users.lock().unwrap();
+        let user = users
+            .values_mut()
+            .find(|u| u.id == user_id)
+            .ok_or_else(|| AppError::NotFound("User not found".to_string()))?;
+        user.failed_attempts = 0;
+        user.locked_until = None;
+        Ok(())
+    }
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -95,6 +128,8 @@ async fn register_with_duplicate_email_returns_conflict() {
         avatar_url: None,
         email_verified_at: None,
         plan: done_with_debt_api::domain::entities::user::Plan::Free,
+        failed_attempts: 0,
+        locked_until: None,
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
     };
@@ -110,7 +145,7 @@ async fn register_with_duplicate_email_returns_conflict() {
 async fn register_with_short_password_returns_validation_error() {
     let service = make_service(InMemoryUserRepository::new());
     let cmd = RegisterCommand {
-        password: "pass1".to_string(), // 5 chars — too short
+        password: "pass1".to_string(), // 5 chars — below 8-char minimum
         ..valid_command()
     };
 

--- a/api/tests/unit/services/auth_service_test.rs
+++ b/api/tests/unit/services/auth_service_test.rs
@@ -9,7 +9,7 @@ use done_with_debt_api::domain::{
     entities::user::User,
     ports::{
         inbound::auth_service::{AuthServicePort, RegisterCommand},
-        outbound::user_repository::UserRepository,
+        outbound::user_repository::{FailedLoginOutcome, UserRepository},
     },
     services::auth_service::AuthService,
 };
@@ -53,25 +53,27 @@ impl UserRepository for InMemoryUserRepository {
         Ok(user)
     }
 
-    async fn record_failed_attempt(&self, user_id: Uuid) -> Result<i32, AppError> {
+    async fn record_failed_attempt(
+        &self,
+        user_id: Uuid,
+        max_attempts: i32,
+        lock_until: DateTime<Utc>,
+    ) -> Result<FailedLoginOutcome, AppError> {
         let mut users = self.users.lock().unwrap();
         let user = users
             .values_mut()
             .find(|u| u.id == user_id)
             .ok_or_else(|| AppError::NotFound("User not found".to_string()))?;
         user.failed_attempts += 1;
-        Ok(user.failed_attempts)
-    }
-
-    async fn lock_until(&self, user_id: Uuid, until: DateTime<Utc>) -> Result<(), AppError> {
-        let mut users = self.users.lock().unwrap();
-        let user = users
-            .values_mut()
-            .find(|u| u.id == user_id)
-            .ok_or_else(|| AppError::NotFound("User not found".to_string()))?;
-        user.locked_until = Some(until);
-        user.failed_attempts = 0;
-        Ok(())
+        if user.failed_attempts >= max_attempts {
+            user.locked_until = Some(lock_until);
+            user.failed_attempts = 0;
+            Ok(FailedLoginOutcome::Locked { until: lock_until })
+        } else {
+            Ok(FailedLoginOutcome::Incremented {
+                attempts: user.failed_attempts,
+            })
+        }
     }
 
     async fn reset_failed_attempts(&self, user_id: Uuid) -> Result<(), AppError> {


### PR DESCRIPTION
## Summary

- Implement `AuthService::login` with argon2 password verification
- Generic `Unauthorized` for both wrong password and unknown email — no enumeration
- Account lockout: 5 failed attempts triggers 15-minute lock via `locked_until`
- Successful login resets the failed attempts counter
- Add `failed_attempts` and `locked_until` to `User` entity and migration
- Add `TooManyRequests` (HTTP 429) variant to `AppError`
- Three new `UserRepository` port methods: `record_failed_attempt`, `lock_until`, `reset_failed_attempts`

## Test plan

- [x] `login_with_valid_credentials_returns_token` — happy path
- [x] `login_with_wrong_password_returns_unauthorized` — generic error
- [x] `login_with_nonexistent_email_returns_same_error_as_wrong_password` — no enumeration
- [x] `login_with_locked_account_returns_too_many_requests` — lockout enforced
- [x] `login_wrong_password_increments_failed_attempts` — counter increments, not locked at 3
- [x] `login_locks_account_after_5_failed_attempts` — 5th attempt locks; 6th blocked even with correct password
- [x] `login_resets_failed_attempts_on_success` — counter resets; full 5 attempts available again

Closes #11