### PR TITLE
feat(auth): sign out with server-side token invalidation

### DIFF
--- a/api/migrations/002_create_auth_tokens.sql
+++ b/api/migrations/002_create_auth_tokens.sql
@@ -1,0 +1,11 @@
+CREATE TABLE auth_tokens (
+    id          UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token       TEXT NOT NULL UNIQUE,
+    expires_at  TIMESTAMPTZ NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_auth_tokens_user_id ON auth_tokens (user_id);
+-- Token lookup on every authenticated request must be fast
+CREATE INDEX idx_auth_tokens_token ON auth_tokens (token);

--- a/api/migrations/002_create_auth_tokens.sql
+++ b/api/migrations/002_create_auth_tokens.sql
@@ -7,5 +7,4 @@ CREATE TABLE auth_tokens (
 );
 
 CREATE INDEX idx_auth_tokens_user_id ON auth_tokens (user_id);
--- Token lookup on every authenticated request must be fast
-CREATE INDEX idx_auth_tokens_token ON auth_tokens (token);
+-- Token lookup on every authenticated request must be fast (uses the UNIQUE index on token)

--- a/api/src/domain/entities/auth_token.rs
+++ b/api/src/domain/entities/auth_token.rs
@@ -1,1 +1,11 @@
-// auth_token entity
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+#[derive(Debug, Clone)]
+pub struct AuthToken {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub token: String,
+    pub expires_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+}

--- a/api/src/domain/ports/inbound/auth_service.rs
+++ b/api/src/domain/ports/inbound/auth_service.rs
@@ -13,6 +13,11 @@ pub struct LoginCommand {
     pub password: String,
 }
 
+pub struct LogoutCommand {
+    /// The raw JWT that was issued at login time.
+    pub token: String,
+}
+
 #[derive(Debug)]
 pub struct AuthResult {
     pub token: String,
@@ -23,4 +28,5 @@ pub struct AuthResult {
 pub trait AuthServicePort: Send + Sync {
     async fn register(&self, cmd: RegisterCommand) -> Result<AuthResult, AppError>;
     async fn login(&self, cmd: LoginCommand) -> Result<AuthResult, AppError>;
+    async fn logout(&self, cmd: LogoutCommand) -> Result<(), AppError>;
 }

--- a/api/src/domain/ports/outbound/auth_token_repository.rs
+++ b/api/src/domain/ports/outbound/auth_token_repository.rs
@@ -1,1 +1,10 @@
-// auth_token_repository outbound port (trait)
+use crate::domain::entities::auth_token::AuthToken;
+use crate::errors::AppError;
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait AuthTokenRepository: Send + Sync {
+    async fn create(&self, token: AuthToken) -> Result<AuthToken, AppError>;
+    async fn find_by_token(&self, token: &str) -> Result<Option<AuthToken>, AppError>;
+    async fn revoke_by_token(&self, token: &str) -> Result<(), AppError>;
+}

--- a/api/src/domain/services/auth_service.rs
+++ b/api/src/domain/services/auth_service.rs
@@ -8,10 +8,12 @@ use jsonwebtoken::{encode, EncodingKey, Header};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::domain::entities::auth_token::AuthToken;
 use crate::domain::entities::user::{Plan, User};
 use crate::domain::ports::inbound::auth_service::{
-    AuthResult, AuthServicePort, LoginCommand, RegisterCommand,
+    AuthResult, AuthServicePort, LoginCommand, LogoutCommand, RegisterCommand,
 };
+use crate::domain::ports::outbound::auth_token_repository::AuthTokenRepository;
 use crate::domain::ports::outbound::user_repository::{FailedLoginOutcome, UserRepository};
 use crate::errors::AppError;
 
@@ -20,20 +22,23 @@ const LOCKOUT_MINUTES: i64 = 15;
 
 #[derive(Serialize, Deserialize)]
 struct Claims {
+    jti: String, // unique token ID — ensures two logins in the same second produce distinct JWTs
     sub: String,
     exp: usize,
 }
 
-pub struct AuthService<U: UserRepository> {
+pub struct AuthService<U: UserRepository, T: AuthTokenRepository> {
     user_repo: U,
+    token_repo: T,
     jwt_secret: String,
     jwt_expiry_hours: u64,
 }
 
-impl<U: UserRepository> AuthService<U> {
-    pub fn new(user_repo: U, jwt_secret: String, jwt_expiry_hours: u64) -> Self {
+impl<U: UserRepository, T: AuthTokenRepository> AuthService<U, T> {
+    pub fn new(user_repo: U, token_repo: T, jwt_secret: String, jwt_expiry_hours: u64) -> Self {
         Self {
             user_repo,
+            token_repo,
             jwt_secret,
             jwt_expiry_hours,
         }
@@ -80,14 +85,19 @@ impl<U: UserRepository> AuthService<U> {
             .unwrap_or(false)
     }
 
+    fn expiry_hours_i64(&self) -> Result<i64, AppError> {
+        i64::try_from(self.jwt_expiry_hours)
+            .map_err(|_| AppError::Internal(anyhow::anyhow!("JWT expiry hours overflow")))
+    }
+
     fn issue_jwt(&self, user_id: Uuid) -> Result<String, AppError> {
-        let expiry_hours = i64::try_from(self.jwt_expiry_hours)
-            .map_err(|_| AppError::Internal(anyhow::anyhow!("JWT expiry hours overflow")))?;
+        let expiry_hours = self.expiry_hours_i64()?;
         let exp = (Utc::now() + Duration::hours(expiry_hours))
             .timestamp()
             .try_into()
             .map_err(|_| AppError::Internal(anyhow::anyhow!("JWT exp timestamp overflow")))?;
         let claims = Claims {
+            jti: Uuid::new_v4().to_string(),
             sub: user_id.to_string(),
             exp,
         };
@@ -98,10 +108,24 @@ impl<U: UserRepository> AuthService<U> {
         )
         .map_err(|e| AppError::Internal(anyhow::anyhow!("JWT error: {}", e)))
     }
+
+    async fn persist_token(&self, user_id: Uuid, token: &str) -> Result<(), AppError> {
+        let expiry_hours = self.expiry_hours_i64()?;
+        self.token_repo
+            .create(AuthToken {
+                id: Uuid::new_v4(),
+                user_id,
+                token: token.to_string(),
+                expires_at: Utc::now() + Duration::hours(expiry_hours),
+                created_at: Utc::now(),
+            })
+            .await?;
+        Ok(())
+    }
 }
 
 #[async_trait]
-impl<U: UserRepository> AuthServicePort for AuthService<U> {
+impl<U: UserRepository, T: AuthTokenRepository> AuthServicePort for AuthService<U, T> {
     async fn register(&self, cmd: RegisterCommand) -> Result<AuthResult, AppError> {
         let email = cmd.email.trim().to_lowercase();
         Self::validate_email(&email)?;
@@ -125,6 +149,7 @@ impl<U: UserRepository> AuthServicePort for AuthService<U> {
 
         let user = self.user_repo.create(user).await?;
         let token = self.issue_jwt(user.id)?;
+        self.persist_token(user.id, &token).await?;
 
         Ok(AuthResult {
             token,
@@ -135,14 +160,12 @@ impl<U: UserRepository> AuthServicePort for AuthService<U> {
     async fn login(&self, cmd: LoginCommand) -> Result<AuthResult, AppError> {
         let email = cmd.email.trim().to_lowercase();
 
-        // Use a generic error for both "not found" and "wrong password" to prevent enumeration
         let user = self
             .user_repo
             .find_by_email(&email)
             .await?
             .ok_or(AppError::Unauthorized)?;
 
-        // Check lockout before verifying password
         if let Some(locked_until) = user.locked_until {
             if locked_until > Utc::now() {
                 return Err(AppError::TooManyRequests(format!(
@@ -174,10 +197,15 @@ impl<U: UserRepository> AuthServicePort for AuthService<U> {
 
         self.user_repo.reset_failed_attempts(user.id).await?;
         let token = self.issue_jwt(user.id)?;
+        self.persist_token(user.id, &token).await?;
 
         Ok(AuthResult {
             token,
             user_id: user.id,
         })
+    }
+
+    async fn logout(&self, cmd: LogoutCommand) -> Result<(), AppError> {
+        self.token_repo.revoke_by_token(&cmd.token).await
     }
 }

--- a/api/tests/unit.rs
+++ b/api/tests/unit.rs
@@ -1,3 +1,6 @@
+#[path = "unit/helpers.rs"]
+pub mod helpers;
+
 #[path = "unit/services/auth_service_test.rs"]
 mod auth_service_test;
 

--- a/api/tests/unit.rs
+++ b/api/tests/unit.rs
@@ -3,3 +3,6 @@ mod auth_service_test;
 
 #[path = "unit/services/auth_service_login_test.rs"]
 mod auth_service_login_test;
+
+#[path = "unit/services/auth_service_logout_test.rs"]
+mod auth_service_logout_test;

--- a/api/tests/unit/helpers.rs
+++ b/api/tests/unit/helpers.rs
@@ -1,0 +1,22 @@
+use async_trait::async_trait;
+use done_with_debt_api::domain::{
+    entities::auth_token::AuthToken, ports::outbound::auth_token_repository::AuthTokenRepository,
+};
+use done_with_debt_api::errors::AppError;
+
+/// Drop-in AuthTokenRepository for tests that don't care about token persistence.
+/// Silently accepts creates, returns None for lookups, and ignores revocations.
+pub struct NoopAuthTokenRepository;
+
+#[async_trait]
+impl AuthTokenRepository for NoopAuthTokenRepository {
+    async fn create(&self, token: AuthToken) -> Result<AuthToken, AppError> {
+        Ok(token)
+    }
+    async fn find_by_token(&self, _token: &str) -> Result<Option<AuthToken>, AppError> {
+        Ok(None)
+    }
+    async fn revoke_by_token(&self, _token: &str) -> Result<(), AppError> {
+        Ok(())
+    }
+}

--- a/api/tests/unit/services/auth_service_login_test.rs
+++ b/api/tests/unit/services/auth_service_login_test.rs
@@ -6,10 +6,16 @@ use chrono::{DateTime, Duration, Utc};
 use uuid::Uuid;
 
 use done_with_debt_api::domain::{
-    entities::user::{Plan, User},
+    entities::{
+        auth_token::AuthToken,
+        user::{Plan, User},
+    },
     ports::{
         inbound::auth_service::{AuthServicePort, LoginCommand},
-        outbound::user_repository::{FailedLoginOutcome, UserRepository},
+        outbound::{
+            auth_token_repository::AuthTokenRepository,
+            user_repository::{FailedLoginOutcome, UserRepository},
+        },
     },
     services::auth_service::AuthService,
 };
@@ -166,8 +172,30 @@ impl UserRepository for SharedRepo {
 
 const JWT_SECRET: &str = "test_secret_key_32_chars_minimum!";
 
-fn make_service(repo: InMemoryUserRepository) -> AuthService<InMemoryUserRepository> {
-    AuthService::new(repo, JWT_SECRET.to_string(), 168_u64)
+struct NoopAuthTokenRepository;
+
+#[async_trait]
+impl AuthTokenRepository for NoopAuthTokenRepository {
+    async fn create(&self, token: AuthToken) -> Result<AuthToken, AppError> {
+        Ok(token)
+    }
+    async fn find_by_token(&self, _token: &str) -> Result<Option<AuthToken>, AppError> {
+        Ok(None)
+    }
+    async fn revoke_by_token(&self, _token: &str) -> Result<(), AppError> {
+        Ok(())
+    }
+}
+
+fn make_service(
+    repo: InMemoryUserRepository,
+) -> AuthService<InMemoryUserRepository, NoopAuthTokenRepository> {
+    AuthService::new(
+        repo,
+        NoopAuthTokenRepository,
+        JWT_SECRET.to_string(),
+        168_u64,
+    )
 }
 
 /// Builds a User with an argon2 hash for the provided password.
@@ -265,6 +293,7 @@ async fn login_wrong_password_increments_failed_attempts() {
     let repo = Arc::new(InMemoryUserRepository::with_user(user));
     let service = AuthService::new(
         SharedRepo(Arc::clone(&repo)),
+        NoopAuthTokenRepository,
         JWT_SECRET.to_string(),
         168_u64,
     );

--- a/api/tests/unit/services/auth_service_login_test.rs
+++ b/api/tests/unit/services/auth_service_login_test.rs
@@ -6,19 +6,15 @@ use chrono::{DateTime, Duration, Utc};
 use uuid::Uuid;
 
 use done_with_debt_api::domain::{
-    entities::{
-        auth_token::AuthToken,
-        user::{Plan, User},
-    },
+    entities::user::{Plan, User},
     ports::{
         inbound::auth_service::{AuthServicePort, LoginCommand},
-        outbound::{
-            auth_token_repository::AuthTokenRepository,
-            user_repository::{FailedLoginOutcome, UserRepository},
-        },
+        outbound::user_repository::{FailedLoginOutcome, UserRepository},
     },
     services::auth_service::AuthService,
 };
+
+use super::helpers::NoopAuthTokenRepository;
 use done_with_debt_api::errors::AppError;
 
 // ── In-memory mock repository ─────────────────────────────────────────────────
@@ -171,21 +167,6 @@ impl UserRepository for SharedRepo {
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 const JWT_SECRET: &str = "test_secret_key_32_chars_minimum!";
-
-struct NoopAuthTokenRepository;
-
-#[async_trait]
-impl AuthTokenRepository for NoopAuthTokenRepository {
-    async fn create(&self, token: AuthToken) -> Result<AuthToken, AppError> {
-        Ok(token)
-    }
-    async fn find_by_token(&self, _token: &str) -> Result<Option<AuthToken>, AppError> {
-        Ok(None)
-    }
-    async fn revoke_by_token(&self, _token: &str) -> Result<(), AppError> {
-        Ok(())
-    }
-}
 
 fn make_service(
     repo: InMemoryUserRepository,

--- a/api/tests/unit/services/auth_service_logout_test.rs
+++ b/api/tests/unit/services/auth_service_logout_test.rs
@@ -1,0 +1,278 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use done_with_debt_api::domain::{
+    entities::{
+        auth_token::AuthToken,
+        user::{Plan, User},
+    },
+    ports::{
+        inbound::auth_service::{AuthServicePort, LoginCommand, LogoutCommand},
+        outbound::{
+            auth_token_repository::AuthTokenRepository,
+            user_repository::{FailedLoginOutcome, UserRepository},
+        },
+    },
+    services::auth_service::AuthService,
+};
+use done_with_debt_api::errors::AppError;
+
+// ── In-memory repositories ────────────────────────────────────────────────────
+
+struct InMemoryUserRepository {
+    users: Mutex<HashMap<String, User>>,
+}
+
+impl InMemoryUserRepository {
+    fn with_user(user: User) -> Self {
+        let mut map = HashMap::new();
+        map.insert(user.email.clone(), user);
+        Self {
+            users: Mutex::new(map),
+        }
+    }
+}
+
+#[async_trait]
+impl UserRepository for InMemoryUserRepository {
+    async fn find_by_email(&self, email: &str) -> Result<Option<User>, AppError> {
+        Ok(self.users.lock().unwrap().get(email).cloned())
+    }
+    async fn create(&self, user: User) -> Result<User, AppError> {
+        self.users
+            .lock()
+            .unwrap()
+            .insert(user.email.clone(), user.clone());
+        Ok(user)
+    }
+    async fn record_failed_attempt(
+        &self,
+        _user_id: Uuid,
+        _max: i32,
+        _lock_until: DateTime<Utc>,
+    ) -> Result<FailedLoginOutcome, AppError> {
+        Ok(FailedLoginOutcome::Incremented { attempts: 1 })
+    }
+    async fn reset_failed_attempts(&self, _user_id: Uuid) -> Result<(), AppError> {
+        Ok(())
+    }
+}
+
+struct InMemoryAuthTokenRepository {
+    tokens: Mutex<HashMap<String, AuthToken>>, // keyed by token string
+}
+
+impl InMemoryAuthTokenRepository {
+    fn new() -> Self {
+        Self {
+            tokens: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn token_exists(&self, token: &str) -> bool {
+        self.tokens.lock().unwrap().contains_key(token)
+    }
+
+    fn token_count(&self) -> usize {
+        self.tokens.lock().unwrap().len()
+    }
+}
+
+#[async_trait]
+impl AuthTokenRepository for InMemoryAuthTokenRepository {
+    async fn create(&self, token: AuthToken) -> Result<AuthToken, AppError> {
+        self.tokens
+            .lock()
+            .unwrap()
+            .insert(token.token.clone(), token.clone());
+        Ok(token)
+    }
+
+    async fn find_by_token(&self, token: &str) -> Result<Option<AuthToken>, AppError> {
+        Ok(self.tokens.lock().unwrap().get(token).cloned())
+    }
+
+    async fn revoke_by_token(&self, token: &str) -> Result<(), AppError> {
+        let mut tokens = self.tokens.lock().unwrap();
+        if tokens.remove(token).is_none() {
+            return Err(AppError::NotFound("Token not found".to_string()));
+        }
+        Ok(())
+    }
+}
+
+// Newtype wrappers for Arc sharing
+struct SharedTokenRepo(Arc<InMemoryAuthTokenRepository>);
+
+#[async_trait]
+impl AuthTokenRepository for SharedTokenRepo {
+    async fn create(&self, token: AuthToken) -> Result<AuthToken, AppError> {
+        self.0.create(token).await
+    }
+    async fn find_by_token(&self, token: &str) -> Result<Option<AuthToken>, AppError> {
+        self.0.find_by_token(token).await
+    }
+    async fn revoke_by_token(&self, token: &str) -> Result<(), AppError> {
+        self.0.revoke_by_token(token).await
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const JWT_SECRET: &str = "test_secret_key_32_chars_minimum!";
+
+fn make_user(password: &str) -> User {
+    use argon2::{
+        password_hash::{rand_core::OsRng, SaltString},
+        Argon2, PasswordHasher,
+    };
+    let salt = SaltString::generate(&mut OsRng);
+    let hash = Argon2::default()
+        .hash_password(password.as_bytes(), &salt)
+        .unwrap()
+        .to_string();
+    User {
+        id: Uuid::new_v4(),
+        email: "john@example.com".to_string(),
+        password_hash: Some(hash),
+        full_name: "John Doe".to_string(),
+        avatar_url: None,
+        email_verified_at: None,
+        plan: Plan::Free,
+        failed_attempts: 0,
+        locked_until: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
+
+fn make_service(
+    user: User,
+    token_repo: Arc<InMemoryAuthTokenRepository>,
+) -> AuthService<InMemoryUserRepository, SharedTokenRepo> {
+    AuthService::new(
+        InMemoryUserRepository::with_user(user),
+        SharedTokenRepo(Arc::clone(&token_repo)),
+        JWT_SECRET.to_string(),
+        168_u64,
+    )
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn login_creates_auth_token_record() {
+    let token_repo = Arc::new(InMemoryAuthTokenRepository::new());
+    let service = make_service(make_user("password1"), Arc::clone(&token_repo));
+
+    let result = service
+        .login(LoginCommand {
+            email: "john@example.com".to_string(),
+            password: "password1".to_string(),
+        })
+        .await
+        .unwrap();
+
+    assert!(token_repo.token_exists(&result.token));
+}
+
+#[tokio::test]
+async fn logout_with_valid_token_succeeds_and_revokes_token() {
+    let token_repo = Arc::new(InMemoryAuthTokenRepository::new());
+    let service = make_service(make_user("password1"), Arc::clone(&token_repo));
+
+    let auth = service
+        .login(LoginCommand {
+            email: "john@example.com".to_string(),
+            password: "password1".to_string(),
+        })
+        .await
+        .unwrap();
+
+    assert!(token_repo.token_exists(&auth.token));
+
+    let result = service
+        .logout(LogoutCommand {
+            token: auth.token.clone(),
+        })
+        .await;
+
+    assert!(result.is_ok());
+    assert!(!token_repo.token_exists(&auth.token));
+}
+
+#[tokio::test]
+async fn logout_with_unknown_token_returns_not_found() {
+    let token_repo = Arc::new(InMemoryAuthTokenRepository::new());
+    let service = make_service(make_user("password1"), Arc::clone(&token_repo));
+
+    let result = service
+        .logout(LogoutCommand {
+            token: "this.token.doesnt.exist".to_string(),
+        })
+        .await;
+
+    assert!(matches!(result, Err(AppError::NotFound(_))));
+}
+
+#[tokio::test]
+async fn multiple_logins_create_separate_tokens() {
+    let token_repo = Arc::new(InMemoryAuthTokenRepository::new());
+    let service = make_service(make_user("password1"), Arc::clone(&token_repo));
+
+    let auth1 = service
+        .login(LoginCommand {
+            email: "john@example.com".to_string(),
+            password: "password1".to_string(),
+        })
+        .await
+        .unwrap();
+
+    let auth2 = service
+        .login(LoginCommand {
+            email: "john@example.com".to_string(),
+            password: "password1".to_string(),
+        })
+        .await
+        .unwrap();
+
+    assert_ne!(auth1.token, auth2.token);
+    assert_eq!(token_repo.token_count(), 2);
+}
+
+#[tokio::test]
+async fn logout_only_revokes_the_specified_token() {
+    let token_repo = Arc::new(InMemoryAuthTokenRepository::new());
+    let service = make_service(make_user("password1"), Arc::clone(&token_repo));
+
+    let auth1 = service
+        .login(LoginCommand {
+            email: "john@example.com".to_string(),
+            password: "password1".to_string(),
+        })
+        .await
+        .unwrap();
+
+    let auth2 = service
+        .login(LoginCommand {
+            email: "john@example.com".to_string(),
+            password: "password1".to_string(),
+        })
+        .await
+        .unwrap();
+
+    service
+        .logout(LogoutCommand {
+            token: auth1.token.clone(),
+        })
+        .await
+        .unwrap();
+
+    // auth1 revoked, auth2 still valid
+    assert!(!token_repo.token_exists(&auth1.token));
+    assert!(token_repo.token_exists(&auth2.token));
+}

--- a/api/tests/unit/services/auth_service_test.rs
+++ b/api/tests/unit/services/auth_service_test.rs
@@ -6,14 +6,34 @@ use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
 use done_with_debt_api::domain::{
-    entities::user::User,
+    entities::{auth_token::AuthToken, user::User},
     ports::{
         inbound::auth_service::{AuthServicePort, RegisterCommand},
-        outbound::user_repository::{FailedLoginOutcome, UserRepository},
+        outbound::{
+            auth_token_repository::AuthTokenRepository,
+            user_repository::{FailedLoginOutcome, UserRepository},
+        },
     },
     services::auth_service::AuthService,
 };
 use done_with_debt_api::errors::AppError;
+
+// ── No-op auth token repository for register tests ───────────────────────────
+
+struct NoopAuthTokenRepository;
+
+#[async_trait]
+impl AuthTokenRepository for NoopAuthTokenRepository {
+    async fn create(&self, token: AuthToken) -> Result<AuthToken, AppError> {
+        Ok(token)
+    }
+    async fn find_by_token(&self, _token: &str) -> Result<Option<AuthToken>, AppError> {
+        Ok(None)
+    }
+    async fn revoke_by_token(&self, _token: &str) -> Result<(), AppError> {
+        Ok(())
+    }
+}
 
 // ── In-memory mock repository ────────────────────────────────────────────────
 
@@ -90,9 +110,12 @@ impl UserRepository for InMemoryUserRepository {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-fn make_service(repo: InMemoryUserRepository) -> AuthService<InMemoryUserRepository> {
+fn make_service(
+    repo: InMemoryUserRepository,
+) -> AuthService<InMemoryUserRepository, NoopAuthTokenRepository> {
     AuthService::new(
         repo,
+        NoopAuthTokenRepository,
         "test_secret_key_32_chars_minimum!".to_string(),
         168_u64,
     )

--- a/api/tests/unit/services/auth_service_test.rs
+++ b/api/tests/unit/services/auth_service_test.rs
@@ -6,34 +6,16 @@ use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
 use done_with_debt_api::domain::{
-    entities::{auth_token::AuthToken, user::User},
+    entities::user::User,
     ports::{
         inbound::auth_service::{AuthServicePort, RegisterCommand},
-        outbound::{
-            auth_token_repository::AuthTokenRepository,
-            user_repository::{FailedLoginOutcome, UserRepository},
-        },
+        outbound::user_repository::{FailedLoginOutcome, UserRepository},
     },
     services::auth_service::AuthService,
 };
 use done_with_debt_api::errors::AppError;
 
-// ── No-op auth token repository for register tests ───────────────────────────
-
-struct NoopAuthTokenRepository;
-
-#[async_trait]
-impl AuthTokenRepository for NoopAuthTokenRepository {
-    async fn create(&self, token: AuthToken) -> Result<AuthToken, AppError> {
-        Ok(token)
-    }
-    async fn find_by_token(&self, _token: &str) -> Result<Option<AuthToken>, AppError> {
-        Ok(None)
-    }
-    async fn revoke_by_token(&self, _token: &str) -> Result<(), AppError> {
-        Ok(())
-    }
-}
+use super::helpers::NoopAuthTokenRepository;
 
 // ── In-memory mock repository ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Add `AuthToken` entity and `AuthTokenRepository` outbound port (`create`, `find_by_token`, `revoke_by_token`)
- Add `LogoutCommand` + `logout()` to `AuthServicePort`
- `AuthService` is now generic over both `UserRepository` and `AuthTokenRepository`
- `login()` and `register()` persist a token record after issuing the JWT
- `logout()` delegates revocation to `AuthTokenRepository::revoke_by_token`
- Add `jti` (UUID v4) claim to JWT so concurrent logins always produce distinct tokens
- Add `002_create_auth_tokens.sql` migration with unique index on `token`

## Test plan

- [x] `login_creates_auth_token_record` — token persisted in repo after login
- [x] `logout_with_valid_token_succeeds_and_revokes_token` — token removed from repo
- [x] `logout_with_unknown_token_returns_not_found` — unknown token returns error
- [x] `multiple_logins_create_separate_tokens` — two logins produce distinct JWTs (jti)
- [x] `logout_only_revokes_the_specified_token` — other sessions unaffected

Closes #7