### PR TITLE
feat(auth): implement session refresh and full auth HTTP adapter

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -1538,6 +1538,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2562,6 +2582,10 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -65,3 +65,4 @@ bigdecimal = { version = "0.4", features = ["serde"] }
 [dev-dependencies]
 testcontainers = "0.15"
 testcontainers-modules = { version = "0.3", features = ["postgres"] }
+tower = { version = "0.4", features = ["util"] }

--- a/api/src/adapters/inbound/http/dto/auth.rs
+++ b/api/src/adapters/inbound/http/dto/auth.rs
@@ -1,1 +1,21 @@
-// auth DTOs
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Deserialize)]
+pub struct RegisterRequest {
+    pub email: String,
+    pub password: String,
+    pub full_name: String,
+}
+
+#[derive(Deserialize)]
+pub struct LoginRequest {
+    pub email: String,
+    pub password: String,
+}
+
+#[derive(Serialize)]
+pub struct AuthResponse {
+    pub token: String,
+    pub user_id: Uuid,
+}

--- a/api/src/adapters/inbound/http/handlers/auth.rs
+++ b/api/src/adapters/inbound/http/handlers/auth.rs
@@ -1,1 +1,151 @@
-// auth handler
+use std::sync::Arc;
+
+use axum::{
+    extract::State,
+    http::{HeaderMap, HeaderValue, StatusCode},
+    response::IntoResponse,
+    Json,
+};
+
+use crate::{
+    adapters::inbound::http::dto::auth::{AuthResponse, LoginRequest, RegisterRequest},
+    domain::ports::inbound::auth_service::{
+        AuthServicePort, LoginCommand, LogoutCommand, RefreshCommand, RegisterCommand,
+    },
+    errors::AppError,
+};
+
+pub struct AuthState {
+    pub service: Arc<dyn AuthServicePort>,
+    pub cookie_secure: bool,
+    pub cookie_same_site: String,
+}
+
+fn auth_cookie(token: &str, secure: bool, same_site: &str) -> HeaderValue {
+    let secure_flag = if secure { "; Secure" } else { "" };
+    HeaderValue::from_str(&format!(
+        "token={}; HttpOnly; Path=/; SameSite={}{}",
+        token, same_site, secure_flag
+    ))
+    .expect("valid cookie header value")
+}
+
+fn clear_cookie() -> HeaderValue {
+    HeaderValue::from_static("token=; HttpOnly; Path=/; Max-Age=0")
+}
+
+/// Extracts the raw JWT from `Authorization: Bearer <token>` or the `token` cookie.
+fn extract_token(headers: &HeaderMap) -> Option<String> {
+    if let Some(auth) = headers.get("authorization") {
+        if let Ok(val) = auth.to_str() {
+            if let Some(token) = val.strip_prefix("Bearer ") {
+                return Some(token.to_string());
+            }
+        }
+    }
+    if let Some(cookie) = headers.get("cookie") {
+        if let Ok(val) = cookie.to_str() {
+            for part in val.split(';') {
+                if let Some(token) = part.trim().strip_prefix("token=") {
+                    return Some(token.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+pub async fn register(
+    State(state): State<Arc<AuthState>>,
+    Json(body): Json<RegisterRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let auth = state
+        .service
+        .register(RegisterCommand {
+            email: body.email,
+            password: body.password,
+            full_name: body.full_name,
+        })
+        .await?;
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "Set-Cookie",
+        auth_cookie(&auth.token, state.cookie_secure, &state.cookie_same_site),
+    );
+
+    Ok((
+        StatusCode::CREATED,
+        headers,
+        Json(AuthResponse {
+            token: auth.token,
+            user_id: auth.user_id,
+        }),
+    ))
+}
+
+pub async fn login(
+    State(state): State<Arc<AuthState>>,
+    Json(body): Json<LoginRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let auth = state
+        .service
+        .login(LoginCommand {
+            email: body.email,
+            password: body.password,
+        })
+        .await?;
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "Set-Cookie",
+        auth_cookie(&auth.token, state.cookie_secure, &state.cookie_same_site),
+    );
+
+    Ok((
+        StatusCode::OK,
+        headers,
+        Json(AuthResponse {
+            token: auth.token,
+            user_id: auth.user_id,
+        }),
+    ))
+}
+
+pub async fn logout(
+    State(state): State<Arc<AuthState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, AppError> {
+    let token = extract_token(&headers).ok_or(AppError::Unauthorized)?;
+
+    state.service.logout(LogoutCommand { token }).await?;
+
+    let mut resp_headers = HeaderMap::new();
+    resp_headers.insert("Set-Cookie", clear_cookie());
+
+    Ok((StatusCode::NO_CONTENT, resp_headers))
+}
+
+pub async fn refresh(
+    State(state): State<Arc<AuthState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, AppError> {
+    let token = extract_token(&headers).ok_or(AppError::Unauthorized)?;
+
+    let auth = state.service.refresh(RefreshCommand { token }).await?;
+
+    let mut resp_headers = HeaderMap::new();
+    resp_headers.insert(
+        "Set-Cookie",
+        auth_cookie(&auth.token, state.cookie_secure, &state.cookie_same_site),
+    );
+
+    Ok((
+        StatusCode::OK,
+        resp_headers,
+        Json(AuthResponse {
+            token: auth.token,
+            user_id: auth.user_id,
+        }),
+    ))
+}

--- a/api/src/adapters/inbound/http/handlers/auth.rs
+++ b/api/src/adapters/inbound/http/handlers/auth.rs
@@ -22,7 +22,12 @@ pub struct AuthState {
     pub cookie_max_age_secs: u64,
 }
 
-fn auth_cookie(token: &str, secure: bool, same_site: &str, max_age_secs: u64) -> HeaderValue {
+fn auth_cookie(
+    token: &str,
+    secure: bool,
+    same_site: &str,
+    max_age_secs: u64,
+) -> Result<HeaderValue, AppError> {
     // SameSite=None requires Secure per spec — enforce it regardless of config.
     let effective_secure = secure || same_site.eq_ignore_ascii_case("none");
     let secure_flag = if effective_secure { "; Secure" } else { "" };
@@ -30,7 +35,7 @@ fn auth_cookie(token: &str, secure: bool, same_site: &str, max_age_secs: u64) ->
         "token={}; HttpOnly; Path=/; SameSite={}; Max-Age={}{}",
         token, same_site, max_age_secs, secure_flag
     ))
-    .expect("valid cookie header value")
+    .map_err(|e| AppError::Internal(anyhow::anyhow!("Invalid Set-Cookie header value: {}", e)))
 }
 
 fn clear_cookie() -> HeaderValue {
@@ -79,7 +84,7 @@ pub async fn register(
             state.cookie_secure,
             &state.cookie_same_site,
             state.cookie_max_age_secs,
-        ),
+        )?,
     );
 
     Ok((
@@ -112,7 +117,7 @@ pub async fn login(
             state.cookie_secure,
             &state.cookie_same_site,
             state.cookie_max_age_secs,
-        ),
+        )?,
     );
 
     Ok((
@@ -155,7 +160,7 @@ pub async fn refresh(
             state.cookie_secure,
             &state.cookie_same_site,
             state.cookie_max_age_secs,
-        ),
+        )?,
     );
 
     Ok((

--- a/api/src/adapters/inbound/http/handlers/auth.rs
+++ b/api/src/adapters/inbound/http/handlers/auth.rs
@@ -19,13 +19,16 @@ pub struct AuthState {
     pub service: Arc<dyn AuthServicePort>,
     pub cookie_secure: bool,
     pub cookie_same_site: String,
+    pub cookie_max_age_secs: u64,
 }
 
-fn auth_cookie(token: &str, secure: bool, same_site: &str) -> HeaderValue {
-    let secure_flag = if secure { "; Secure" } else { "" };
+fn auth_cookie(token: &str, secure: bool, same_site: &str, max_age_secs: u64) -> HeaderValue {
+    // SameSite=None requires Secure per spec — enforce it regardless of config.
+    let effective_secure = secure || same_site.eq_ignore_ascii_case("none");
+    let secure_flag = if effective_secure { "; Secure" } else { "" };
     HeaderValue::from_str(&format!(
-        "token={}; HttpOnly; Path=/; SameSite={}{}",
-        token, same_site, secure_flag
+        "token={}; HttpOnly; Path=/; SameSite={}; Max-Age={}{}",
+        token, same_site, max_age_secs, secure_flag
     ))
     .expect("valid cookie header value")
 }
@@ -71,7 +74,12 @@ pub async fn register(
     let mut headers = HeaderMap::new();
     headers.insert(
         "Set-Cookie",
-        auth_cookie(&auth.token, state.cookie_secure, &state.cookie_same_site),
+        auth_cookie(
+            &auth.token,
+            state.cookie_secure,
+            &state.cookie_same_site,
+            state.cookie_max_age_secs,
+        ),
     );
 
     Ok((
@@ -99,7 +107,12 @@ pub async fn login(
     let mut headers = HeaderMap::new();
     headers.insert(
         "Set-Cookie",
-        auth_cookie(&auth.token, state.cookie_secure, &state.cookie_same_site),
+        auth_cookie(
+            &auth.token,
+            state.cookie_secure,
+            &state.cookie_same_site,
+            state.cookie_max_age_secs,
+        ),
     );
 
     Ok((
@@ -137,7 +150,12 @@ pub async fn refresh(
     let mut resp_headers = HeaderMap::new();
     resp_headers.insert(
         "Set-Cookie",
-        auth_cookie(&auth.token, state.cookie_secure, &state.cookie_same_site),
+        auth_cookie(
+            &auth.token,
+            state.cookie_secure,
+            &state.cookie_same_site,
+            state.cookie_max_age_secs,
+        ),
     );
 
     Ok((

--- a/api/src/adapters/inbound/http/handlers/auth.rs
+++ b/api/src/adapters/inbound/http/handlers/auth.rs
@@ -53,7 +53,38 @@ fn auth_cookie(
 }
 
 fn clear_cookie() -> HeaderValue {
-    HeaderValue::from_static("token=; HttpOnly; Path=/; Max-Age=0")
+    // Mirror the SameSite/Secure logic used for the auth cookie so that the
+    // clearing Set-Cookie reliably targets the same cookie instance.
+    let same_site = std::env::var("COOKIE_SAME_SITE").unwrap_or_else(|_| "Lax".to_string());
+    let normalized_same_site = if same_site.eq_ignore_ascii_case("strict") {
+        "Strict"
+    } else if same_site.eq_ignore_ascii_case("lax") {
+        "Lax"
+    } else if same_site.eq_ignore_ascii_case("none") {
+        "None"
+    } else {
+        // Fall back to a safe default rather than failing, since this function
+        // does not return a Result.
+        "Lax"
+    };
+
+    // Interpret COOKIE_SECURE in a forgiving way: "true"/"1" enable Secure.
+    let secure = std::env::var("COOKIE_SECURE")
+        .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+        .unwrap_or(false);
+
+    // SameSite=None requires Secure per spec — enforce it regardless of config.
+    let effective_secure = secure || normalized_same_site == "None";
+    let secure_flag = if effective_secure { "; Secure" } else { "" };
+
+    let value = format!(
+        "token=; HttpOnly; Path=/; SameSite={}; Max-Age=0{}",
+        normalized_same_site, secure_flag
+    );
+
+    HeaderValue::from_str(&value)
+        // On any error constructing the header, fall back to the previous behavior.
+        .unwrap_or_else(|_| HeaderValue::from_static("token=; HttpOnly; Path=/; Max-Age=0"))
 }
 
 /// Extracts the raw JWT from `Authorization: Bearer <token>` or the `token` cookie.

--- a/api/src/adapters/inbound/http/handlers/auth.rs
+++ b/api/src/adapters/inbound/http/handlers/auth.rs
@@ -43,11 +43,18 @@ fn clear_cookie() -> HeaderValue {
 }
 
 /// Extracts the raw JWT from `Authorization: Bearer <token>` or the `token` cookie.
+/// The Bearer scheme comparison is case-insensitive per RFC 7235.
 fn extract_token(headers: &HeaderMap) -> Option<String> {
     if let Some(auth) = headers.get("authorization") {
         if let Ok(val) = auth.to_str() {
-            if let Some(token) = val.strip_prefix("Bearer ") {
-                return Some(token.to_string());
+            let mut parts = val.splitn(2, |c: char| c.is_ascii_whitespace());
+            if let (Some(scheme), Some(token)) = (parts.next(), parts.next()) {
+                if scheme.eq_ignore_ascii_case("bearer") {
+                    let token = token.trim();
+                    if !token.is_empty() {
+                        return Some(token.to_string());
+                    }
+                }
             }
         }
     }

--- a/api/src/adapters/inbound/http/handlers/auth.rs
+++ b/api/src/adapters/inbound/http/handlers/auth.rs
@@ -28,12 +28,26 @@ fn auth_cookie(
     same_site: &str,
     max_age_secs: u64,
 ) -> Result<HeaderValue, AppError> {
+    // Validate SameSite against the allowed set to prevent attribute injection.
+    let normalized_same_site = if same_site.eq_ignore_ascii_case("strict") {
+        "Strict"
+    } else if same_site.eq_ignore_ascii_case("lax") {
+        "Lax"
+    } else if same_site.eq_ignore_ascii_case("none") {
+        "None"
+    } else {
+        return Err(AppError::Internal(anyhow::anyhow!(
+            "Invalid COOKIE_SAME_SITE value: {:?}; must be Strict, Lax, or None",
+            same_site
+        )));
+    };
+
     // SameSite=None requires Secure per spec — enforce it regardless of config.
-    let effective_secure = secure || same_site.eq_ignore_ascii_case("none");
+    let effective_secure = secure || normalized_same_site == "None";
     let secure_flag = if effective_secure { "; Secure" } else { "" };
     HeaderValue::from_str(&format!(
         "token={}; HttpOnly; Path=/; SameSite={}; Max-Age={}{}",
-        token, same_site, max_age_secs, secure_flag
+        token, normalized_same_site, max_age_secs, secure_flag
     ))
     .map_err(|e| AppError::Internal(anyhow::anyhow!("Invalid Set-Cookie header value: {}", e)))
 }
@@ -62,7 +76,10 @@ fn extract_token(headers: &HeaderMap) -> Option<String> {
         if let Ok(val) = cookie.to_str() {
             for part in val.split(';') {
                 if let Some(token) = part.trim().strip_prefix("token=") {
-                    return Some(token.to_string());
+                    let token = token.trim();
+                    if !token.is_empty() {
+                        return Some(token.to_string());
+                    }
                 }
             }
         }

--- a/api/src/adapters/inbound/http/router.rs
+++ b/api/src/adapters/inbound/http/router.rs
@@ -14,7 +14,7 @@ use crate::{
             user_repository::PostgresUserRepository,
         },
     },
-    config::Config,
+    config::{hours_to_max_age_secs, Config},
     domain::{ports::inbound::auth_service::AuthServicePort, services::auth_service::AuthService},
 };
 
@@ -30,7 +30,8 @@ pub fn create_router(pool: Arc<PgPool>, config: &Config) -> Router {
         service: auth_service,
         cookie_secure: config.cookie_secure,
         cookie_same_site: config.cookie_same_site.clone(),
-        cookie_max_age_secs: config.jwt_expiry_hours * 3600,
+        cookie_max_age_secs: hours_to_max_age_secs(config.jwt_expiry_hours)
+            .expect("JWT_EXPIRY_HOURS * 3600 overflows u64; use a smaller value"),
     });
 
     let auth_routes = Router::new()

--- a/api/src/adapters/inbound/http/router.rs
+++ b/api/src/adapters/inbound/http/router.rs
@@ -1,7 +1,43 @@
-use axum::Router;
-use sqlx::PgPool;
 use std::sync::Arc;
 
-pub fn create_router(_pool: Arc<PgPool>) -> Router {
-    Router::new()
+use axum::{
+    routing::{delete, post},
+    Router,
+};
+use sqlx::PgPool;
+
+use crate::{
+    adapters::{
+        inbound::http::handlers::auth::{login, logout, refresh, register, AuthState},
+        outbound::postgres::{
+            auth_token_repository::PostgresAuthTokenRepository,
+            user_repository::PostgresUserRepository,
+        },
+    },
+    config::Config,
+    domain::{ports::inbound::auth_service::AuthServicePort, services::auth_service::AuthService},
+};
+
+pub fn create_router(pool: Arc<PgPool>, config: &Config) -> Router {
+    let auth_service: Arc<dyn AuthServicePort> = Arc::new(AuthService::new(
+        PostgresUserRepository::new(Arc::clone(&pool)),
+        PostgresAuthTokenRepository::new(Arc::clone(&pool)),
+        config.jwt_secret.clone(),
+        config.jwt_expiry_hours,
+    ));
+
+    let auth_state = Arc::new(AuthState {
+        service: auth_service,
+        cookie_secure: config.cookie_secure,
+        cookie_same_site: config.cookie_same_site.clone(),
+    });
+
+    let auth_routes = Router::new()
+        .route("/register", post(register))
+        .route("/login", post(login))
+        .route("/logout", delete(logout))
+        .route("/refresh", post(refresh))
+        .with_state(auth_state);
+
+    Router::new().nest("/auth", auth_routes)
 }

--- a/api/src/adapters/inbound/http/router.rs
+++ b/api/src/adapters/inbound/http/router.rs
@@ -30,6 +30,7 @@ pub fn create_router(pool: Arc<PgPool>, config: &Config) -> Router {
         service: auth_service,
         cookie_secure: config.cookie_secure,
         cookie_same_site: config.cookie_same_site.clone(),
+        cookie_max_age_secs: config.jwt_expiry_hours * 3600,
     });
 
     let auth_routes = Router::new()

--- a/api/src/adapters/outbound/postgres/auth_token_repository.rs
+++ b/api/src/adapters/outbound/postgres/auth_token_repository.rs
@@ -83,4 +83,35 @@ impl AuthTokenRepository for PostgresAuthTokenRepository {
 
         Ok(())
     }
+
+    async fn rotate_token(
+        &self,
+        old_token: &str,
+        new_token: AuthToken,
+    ) -> Result<AuthToken, AppError> {
+        let mut tx = self.pool.begin().await?;
+
+        sqlx::query(
+            r#"
+            INSERT INTO auth_tokens (id, user_id, token, expires_at, created_at)
+            VALUES ($1, $2, $3, $4, $5)
+            "#,
+        )
+        .bind(new_token.id)
+        .bind(new_token.user_id)
+        .bind(&new_token.token)
+        .bind(new_token.expires_at)
+        .bind(new_token.created_at)
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query("DELETE FROM auth_tokens WHERE token = $1")
+            .bind(old_token)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+
+        Ok(new_token)
+    }
 }

--- a/api/src/adapters/outbound/postgres/auth_token_repository.rs
+++ b/api/src/adapters/outbound/postgres/auth_token_repository.rs
@@ -1,1 +1,86 @@
-// auth_token_repository postgres implementation
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::domain::entities::auth_token::AuthToken;
+use crate::domain::ports::outbound::auth_token_repository::AuthTokenRepository;
+use crate::errors::AppError;
+
+pub struct PostgresAuthTokenRepository {
+    pool: Arc<PgPool>,
+}
+
+impl PostgresAuthTokenRepository {
+    pub fn new(pool: Arc<PgPool>) -> Self {
+        Self { pool }
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct AuthTokenRow {
+    id: Uuid,
+    user_id: Uuid,
+    token: String,
+    expires_at: DateTime<Utc>,
+    created_at: DateTime<Utc>,
+}
+
+impl From<AuthTokenRow> for AuthToken {
+    fn from(row: AuthTokenRow) -> Self {
+        AuthToken {
+            id: row.id,
+            user_id: row.user_id,
+            token: row.token,
+            expires_at: row.expires_at,
+            created_at: row.created_at,
+        }
+    }
+}
+
+#[async_trait]
+impl AuthTokenRepository for PostgresAuthTokenRepository {
+    async fn create(&self, token: AuthToken) -> Result<AuthToken, AppError> {
+        sqlx::query(
+            r#"
+            INSERT INTO auth_tokens (id, user_id, token, expires_at, created_at)
+            VALUES ($1, $2, $3, $4, $5)
+            "#,
+        )
+        .bind(token.id)
+        .bind(token.user_id)
+        .bind(&token.token)
+        .bind(token.expires_at)
+        .bind(token.created_at)
+        .execute(&*self.pool)
+        .await?;
+
+        Ok(token)
+    }
+
+    async fn find_by_token(&self, token: &str) -> Result<Option<AuthToken>, AppError> {
+        let row = sqlx::query_as::<_, AuthTokenRow>(
+            r#"
+            SELECT id, user_id, token, expires_at, created_at
+            FROM auth_tokens
+            WHERE token = $1
+            "#,
+        )
+        .bind(token)
+        .fetch_optional(&*self.pool)
+        .await?;
+
+        Ok(row.map(AuthToken::from))
+    }
+
+    async fn revoke_by_token(&self, token: &str) -> Result<(), AppError> {
+        sqlx::query("DELETE FROM auth_tokens WHERE token = $1")
+            .bind(token)
+            .execute(&*self.pool)
+            .await?;
+
+        Ok(())
+    }
+}

--- a/api/src/adapters/outbound/postgres/auth_token_repository.rs
+++ b/api/src/adapters/outbound/postgres/auth_token_repository.rs
@@ -91,6 +91,16 @@ impl AuthTokenRepository for PostgresAuthTokenRepository {
     ) -> Result<AuthToken, AppError> {
         let mut tx = self.pool.begin().await?;
 
+        let deleted = sqlx::query("DELETE FROM auth_tokens WHERE token = $1")
+            .bind(old_token)
+            .execute(&mut *tx)
+            .await?;
+
+        if deleted.rows_affected() == 0 {
+            tx.rollback().await?;
+            return Err(AppError::Unauthorized);
+        }
+
         sqlx::query(
             r#"
             INSERT INTO auth_tokens (id, user_id, token, expires_at, created_at)
@@ -104,11 +114,6 @@ impl AuthTokenRepository for PostgresAuthTokenRepository {
         .bind(new_token.created_at)
         .execute(&mut *tx)
         .await?;
-
-        sqlx::query("DELETE FROM auth_tokens WHERE token = $1")
-            .bind(old_token)
-            .execute(&mut *tx)
-            .await?;
 
         tx.commit().await?;
 

--- a/api/src/adapters/outbound/postgres/auth_token_repository.rs
+++ b/api/src/adapters/outbound/postgres/auth_token_repository.rs
@@ -76,10 +76,14 @@ impl AuthTokenRepository for PostgresAuthTokenRepository {
     }
 
     async fn revoke_by_token(&self, token: &str) -> Result<(), AppError> {
-        sqlx::query("DELETE FROM auth_tokens WHERE token = $1")
+        let result = sqlx::query("DELETE FROM auth_tokens WHERE token = $1")
             .bind(token)
             .execute(&*self.pool)
             .await?;
+
+        if result.rows_affected() == 0 {
+            return Err(AppError::NotFound("Token not found".to_string()));
+        }
 
         Ok(())
     }

--- a/api/src/adapters/outbound/postgres/user_repository.rs
+++ b/api/src/adapters/outbound/postgres/user_repository.rs
@@ -77,10 +77,7 @@ impl UserRepository for PostgresUserRepository {
     }
 
     async fn create(&self, user: User) -> Result<User, AppError> {
-        let plan_str = match user.plan {
-            Plan::Free => "free",
-            Plan::Premium => "premium",
-        };
+        let plan_str = user.plan.as_str();
 
         sqlx::query(
             r#"

--- a/api/src/adapters/outbound/postgres/user_repository.rs
+++ b/api/src/adapters/outbound/postgres/user_repository.rs
@@ -99,7 +99,15 @@ impl UserRepository for PostgresUserRepository {
         .bind(user.created_at)
         .bind(user.updated_at)
         .execute(&*self.pool)
-        .await?;
+        .await
+        .map_err(|e| {
+            if let sqlx::Error::Database(ref db_err) = e {
+                if db_err.code().as_deref() == Some("23505") {
+                    return AppError::Conflict("Email already in use".to_string());
+                }
+            }
+            AppError::Database(e)
+        })?;
 
         Ok(user)
     }

--- a/api/src/adapters/outbound/postgres/user_repository.rs
+++ b/api/src/adapters/outbound/postgres/user_repository.rs
@@ -1,1 +1,167 @@
-// user_repository postgres implementation
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::domain::entities::user::{Plan, User};
+use crate::domain::ports::outbound::user_repository::{FailedLoginOutcome, UserRepository};
+use crate::errors::AppError;
+
+pub struct PostgresUserRepository {
+    pool: Arc<PgPool>,
+}
+
+impl PostgresUserRepository {
+    pub fn new(pool: Arc<PgPool>) -> Self {
+        Self { pool }
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct UserRow {
+    id: Uuid,
+    full_name: String,
+    email: String,
+    password_hash: Option<String>,
+    avatar_url: Option<String>,
+    email_verified_at: Option<DateTime<Utc>>,
+    plan: String,
+    failed_attempts: i32,
+    locked_until: Option<DateTime<Utc>>,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+impl TryFrom<UserRow> for User {
+    type Error = AppError;
+
+    fn try_from(row: UserRow) -> Result<Self, Self::Error> {
+        let plan = row.plan.parse::<Plan>().map_err(|e| {
+            AppError::Internal(anyhow::anyhow!("Invalid plan value in database: {}", e))
+        })?;
+        Ok(User {
+            id: row.id,
+            full_name: row.full_name,
+            email: row.email,
+            password_hash: row.password_hash,
+            avatar_url: row.avatar_url,
+            email_verified_at: row.email_verified_at,
+            plan,
+            failed_attempts: row.failed_attempts,
+            locked_until: row.locked_until,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+        })
+    }
+}
+
+#[async_trait]
+impl UserRepository for PostgresUserRepository {
+    async fn find_by_email(&self, email: &str) -> Result<Option<User>, AppError> {
+        let row = sqlx::query_as::<_, UserRow>(
+            r#"
+            SELECT id, full_name, email, password_hash, avatar_url,
+                   email_verified_at, plan, failed_attempts, locked_until,
+                   created_at, updated_at
+            FROM users
+            WHERE email = $1 AND deleted_at IS NULL
+            "#,
+        )
+        .bind(email)
+        .fetch_optional(&*self.pool)
+        .await?;
+
+        row.map(User::try_from).transpose()
+    }
+
+    async fn create(&self, user: User) -> Result<User, AppError> {
+        let plan_str = match user.plan {
+            Plan::Free => "free",
+            Plan::Premium => "premium",
+        };
+
+        sqlx::query(
+            r#"
+            INSERT INTO users (id, full_name, email, password_hash, avatar_url,
+                               email_verified_at, plan, failed_attempts, locked_until,
+                               created_at, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            "#,
+        )
+        .bind(user.id)
+        .bind(&user.full_name)
+        .bind(&user.email)
+        .bind(&user.password_hash)
+        .bind(&user.avatar_url)
+        .bind(user.email_verified_at)
+        .bind(plan_str)
+        .bind(user.failed_attempts)
+        .bind(user.locked_until)
+        .bind(user.created_at)
+        .bind(user.updated_at)
+        .execute(&*self.pool)
+        .await?;
+
+        Ok(user)
+    }
+
+    async fn record_failed_attempt(
+        &self,
+        user_id: Uuid,
+        max_attempts: i32,
+        lock_until: DateTime<Utc>,
+    ) -> Result<FailedLoginOutcome, AppError> {
+        // Atomically increment or lock in a single UPDATE.
+        // On lock: failed_attempts is reset to 0 and locked_until is set.
+        let row = sqlx::query_as::<_, (i32, Option<DateTime<Utc>>)>(
+            r#"
+            UPDATE users
+            SET
+                failed_attempts = CASE
+                    WHEN failed_attempts + 1 >= $2 THEN 0
+                    ELSE failed_attempts + 1
+                END,
+                locked_until = CASE
+                    WHEN failed_attempts + 1 >= $2 THEN $3
+                    ELSE locked_until
+                END,
+                updated_at = NOW()
+            WHERE id = $1 AND deleted_at IS NULL
+            RETURNING failed_attempts, locked_until
+            "#,
+        )
+        .bind(user_id)
+        .bind(max_attempts)
+        .bind(lock_until)
+        .fetch_one(&*self.pool)
+        .await?;
+
+        let (new_attempts, new_locked_until) = row;
+
+        // failed_attempts == 0 with locked_until set means the account was just locked
+        if let Some(until) = new_locked_until.filter(|_| new_attempts == 0) {
+            Ok(FailedLoginOutcome::Locked { until })
+        } else {
+            Ok(FailedLoginOutcome::Incremented {
+                attempts: new_attempts,
+            })
+        }
+    }
+
+    async fn reset_failed_attempts(&self, user_id: Uuid) -> Result<(), AppError> {
+        sqlx::query(
+            r#"
+            UPDATE users
+            SET failed_attempts = 0, locked_until = NULL, updated_at = NOW()
+            WHERE id = $1 AND deleted_at IS NULL
+            "#,
+        )
+        .bind(user_id)
+        .execute(&*self.pool)
+        .await?;
+
+        Ok(())
+    }
+}

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -1,5 +1,11 @@
 use std::env;
 
+/// Converts JWT expiry hours to cookie Max-Age seconds.
+/// Returns `None` if the multiplication would overflow `u64`.
+pub fn hours_to_max_age_secs(hours: u64) -> Option<u64> {
+    hours.checked_mul(3600)
+}
+
 #[derive(Debug, Clone)]
 pub struct Config {
     pub host: String,

--- a/api/src/domain/ports/inbound/auth_service.rs
+++ b/api/src/domain/ports/inbound/auth_service.rs
@@ -18,6 +18,11 @@ pub struct LogoutCommand {
     pub token: String,
 }
 
+pub struct RefreshCommand {
+    /// The current valid JWT to be rotated.
+    pub token: String,
+}
+
 #[derive(Debug)]
 pub struct AuthResult {
     pub token: String,
@@ -29,4 +34,5 @@ pub trait AuthServicePort: Send + Sync {
     async fn register(&self, cmd: RegisterCommand) -> Result<AuthResult, AppError>;
     async fn login(&self, cmd: LoginCommand) -> Result<AuthResult, AppError>;
     async fn logout(&self, cmd: LogoutCommand) -> Result<(), AppError>;
+    async fn refresh(&self, cmd: RefreshCommand) -> Result<AuthResult, AppError>;
 }

--- a/api/src/domain/ports/outbound/auth_token_repository.rs
+++ b/api/src/domain/ports/outbound/auth_token_repository.rs
@@ -7,4 +7,11 @@ pub trait AuthTokenRepository: Send + Sync {
     async fn create(&self, token: AuthToken) -> Result<AuthToken, AppError>;
     async fn find_by_token(&self, token: &str) -> Result<Option<AuthToken>, AppError>;
     async fn revoke_by_token(&self, token: &str) -> Result<(), AppError>;
+    /// Atomically swap old_token for new_token. Neither change is visible if
+    /// the operation fails — implementations must enforce this guarantee.
+    async fn rotate_token(
+        &self,
+        old_token: &str,
+        new_token: AuthToken,
+    ) -> Result<AuthToken, AppError>;
 }

--- a/api/src/domain/services/auth_service.rs
+++ b/api/src/domain/services/auth_service.rs
@@ -223,18 +223,32 @@ impl<U: UserRepository, T: AuthTokenRepository> AuthServicePort for AuthService<
         // Validate JWT signature and expiry
         let user_id = self.decode_jwt(&cmd.token)?;
 
-        // Ensure the token is still active (not revoked)
-        self.token_repo
+        // Ensure the token is still active (not revoked) and belongs to the same user
+        let stored = self
+            .token_repo
             .find_by_token(&cmd.token)
             .await?
             .ok_or(AppError::Unauthorized)?;
+        if stored.user_id != user_id {
+            return Err(AppError::Unauthorized);
+        }
 
-        let new_token = self.issue_jwt(user_id)?;
-        self.persist_token(user_id, &new_token).await?;
-        self.token_repo.revoke_by_token(&cmd.token).await?;
+        let expiry_hours = self.expiry_hours_i64()?;
+        let new_token_str = self.issue_jwt(user_id)?;
+        let new_auth_token = AuthToken {
+            id: Uuid::new_v4(),
+            user_id,
+            token: new_token_str.clone(),
+            expires_at: Utc::now() + Duration::hours(expiry_hours),
+            created_at: Utc::now(),
+        };
+
+        self.token_repo
+            .rotate_token(&cmd.token, new_auth_token)
+            .await?;
 
         Ok(AuthResult {
-            token: new_token,
+            token: new_token_str,
             user_id,
         })
     }

--- a/api/src/domain/services/auth_service.rs
+++ b/api/src/domain/services/auth_service.rs
@@ -4,14 +4,14 @@ use argon2::{
 };
 use async_trait::async_trait;
 use chrono::{Duration, Utc};
-use jsonwebtoken::{encode, EncodingKey, Header};
+use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::domain::entities::auth_token::AuthToken;
 use crate::domain::entities::user::{Plan, User};
 use crate::domain::ports::inbound::auth_service::{
-    AuthResult, AuthServicePort, LoginCommand, LogoutCommand, RegisterCommand,
+    AuthResult, AuthServicePort, LoginCommand, LogoutCommand, RefreshCommand, RegisterCommand,
 };
 use crate::domain::ports::outbound::auth_token_repository::AuthTokenRepository;
 use crate::domain::ports::outbound::user_repository::{FailedLoginOutcome, UserRepository};
@@ -107,6 +107,16 @@ impl<U: UserRepository, T: AuthTokenRepository> AuthService<U, T> {
             &EncodingKey::from_secret(self.jwt_secret.as_bytes()),
         )
         .map_err(|e| AppError::Internal(anyhow::anyhow!("JWT error: {}", e)))
+    }
+
+    fn decode_jwt(&self, token: &str) -> Result<Uuid, AppError> {
+        let data = decode::<Claims>(
+            token,
+            &DecodingKey::from_secret(self.jwt_secret.as_bytes()),
+            &Validation::default(),
+        )
+        .map_err(|_| AppError::Unauthorized)?;
+        Uuid::parse_str(&data.claims.sub).map_err(|_| AppError::Unauthorized)
     }
 
     async fn persist_token(&self, user_id: Uuid, token: &str) -> Result<(), AppError> {
@@ -207,5 +217,25 @@ impl<U: UserRepository, T: AuthTokenRepository> AuthServicePort for AuthService<
 
     async fn logout(&self, cmd: LogoutCommand) -> Result<(), AppError> {
         self.token_repo.revoke_by_token(&cmd.token).await
+    }
+
+    async fn refresh(&self, cmd: RefreshCommand) -> Result<AuthResult, AppError> {
+        // Validate JWT signature and expiry
+        let user_id = self.decode_jwt(&cmd.token)?;
+
+        // Ensure the token is still active (not revoked)
+        self.token_repo
+            .find_by_token(&cmd.token)
+            .await?
+            .ok_or(AppError::Unauthorized)?;
+
+        let new_token = self.issue_jwt(user_id)?;
+        self.persist_token(user_id, &new_token).await?;
+        self.token_repo.revoke_by_token(&cmd.token).await?;
+
+        Ok(AuthResult {
+            token: new_token,
+            user_id,
+        })
     }
 }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -15,7 +15,7 @@ async fn main() {
         .await
         .expect("Failed to connect to database");
 
-    let app = adapters::inbound::http::router::create_router(Arc::new(pool));
+    let app = adapters::inbound::http::router::create_router(Arc::new(pool), &config);
 
     let listener = tokio::net::TcpListener::bind(format!("{}:{}", config.host, config.port))
         .await

--- a/api/tests/integration.rs
+++ b/api/tests/integration.rs
@@ -1,0 +1,2 @@
+#[path = "integration/user_repository_test.rs"]
+mod user_repository_test;

--- a/api/tests/integration.rs
+++ b/api/tests/integration.rs
@@ -1,2 +1,5 @@
 #[path = "integration/user_repository_test.rs"]
 mod user_repository_test;
+
+#[path = "integration/auth_token_repository_test.rs"]
+mod auth_token_repository_test;

--- a/api/tests/integration/auth_token_repository_test.rs
+++ b/api/tests/integration/auth_token_repository_test.rs
@@ -50,6 +50,27 @@ fn make_token(user_id: Uuid) -> AuthToken {
 }
 
 #[tokio::test]
+async fn revoke_by_token_with_unknown_token_returns_not_found() {
+    let docker = clients::Cli::default();
+    let pg = docker.run(Postgres::default());
+    let port = pg.get_host_port_ipv4(5432);
+
+    let url = format!("postgres://postgres:postgres@127.0.0.1:{}/postgres", port);
+    let pool = Arc::new(sqlx::PgPool::connect(&url).await.unwrap());
+    sqlx::migrate!("./migrations").run(&*pool).await.unwrap();
+
+    let repo = PostgresAuthTokenRepository::new(Arc::clone(&pool));
+
+    let result = repo.revoke_by_token("this.token.does.not.exist").await;
+
+    assert!(
+        matches!(result, Err(AppError::NotFound(_))),
+        "revoking an unknown token must return NotFound, got {:?}",
+        result
+    );
+}
+
+#[tokio::test]
 async fn rotate_token_with_already_rotated_old_token_returns_unauthorized() {
     let docker = clients::Cli::default();
     let pg = docker.run(Postgres::default());

--- a/api/tests/integration/auth_token_repository_test.rs
+++ b/api/tests/integration/auth_token_repository_test.rs
@@ -1,0 +1,83 @@
+use std::sync::Arc;
+
+use chrono::{Duration, Utc};
+use testcontainers::clients;
+use testcontainers_modules::postgres::Postgres;
+use uuid::Uuid;
+
+use done_with_debt_api::{
+    adapters::outbound::postgres::{
+        auth_token_repository::PostgresAuthTokenRepository, user_repository::PostgresUserRepository,
+    },
+    domain::{
+        entities::{
+            auth_token::AuthToken,
+            user::{Plan, User},
+        },
+        ports::outbound::{
+            auth_token_repository::AuthTokenRepository, user_repository::UserRepository,
+        },
+    },
+    errors::AppError,
+};
+
+fn make_user() -> User {
+    let now = Utc::now();
+    User {
+        id: Uuid::new_v4(),
+        email: format!("{}@example.com", Uuid::new_v4()),
+        password_hash: Some("hash".to_string()),
+        full_name: "Test User".to_string(),
+        avatar_url: None,
+        email_verified_at: None,
+        plan: Plan::Free,
+        failed_attempts: 0,
+        locked_until: None,
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+fn make_token(user_id: Uuid) -> AuthToken {
+    let now = Utc::now();
+    AuthToken {
+        id: Uuid::new_v4(),
+        user_id,
+        token: Uuid::new_v4().to_string(),
+        expires_at: now + Duration::hours(168),
+        created_at: now,
+    }
+}
+
+#[tokio::test]
+async fn rotate_token_with_already_rotated_old_token_returns_unauthorized() {
+    let docker = clients::Cli::default();
+    let pg = docker.run(Postgres::default());
+    let port = pg.get_host_port_ipv4(5432);
+
+    let url = format!("postgres://postgres:postgres@127.0.0.1:{}/postgres", port);
+    let pool = Arc::new(sqlx::PgPool::connect(&url).await.unwrap());
+    sqlx::migrate!("./migrations").run(&*pool).await.unwrap();
+
+    let user_repo = PostgresUserRepository::new(Arc::clone(&pool));
+    let user = user_repo.create(make_user()).await.unwrap();
+
+    let repo = PostgresAuthTokenRepository::new(Arc::clone(&pool));
+
+    let old = make_token(user.id);
+    repo.create(old.clone()).await.unwrap();
+
+    // First rotation succeeds: old is deleted, new1 is inserted.
+    let new1 = make_token(user.id);
+    repo.rotate_token(&old.token, new1).await.unwrap();
+
+    // Second rotation with the same old token must fail: old is already gone.
+    let new2 = make_token(user.id);
+    let result = repo.rotate_token(&old.token, new2).await;
+
+    assert!(
+        matches!(result, Err(AppError::Unauthorized)),
+        "rotating an already-rotated token must return Unauthorized, got {:?}",
+        result
+    );
+}

--- a/api/tests/integration/user_repository_test.rs
+++ b/api/tests/integration/user_repository_test.rs
@@ -1,0 +1,54 @@
+use std::sync::Arc;
+
+use chrono::Utc;
+use testcontainers::clients;
+use testcontainers_modules::postgres::Postgres;
+use uuid::Uuid;
+
+use done_with_debt_api::{
+    adapters::outbound::postgres::user_repository::PostgresUserRepository,
+    domain::{
+        entities::user::{Plan, User},
+        ports::outbound::user_repository::UserRepository,
+    },
+    errors::AppError,
+};
+
+fn make_user(email: &str) -> User {
+    let now = Utc::now();
+    User {
+        id: Uuid::new_v4(),
+        email: email.to_string(),
+        password_hash: Some("hash".to_string()),
+        full_name: "Test User".to_string(),
+        avatar_url: None,
+        email_verified_at: None,
+        plan: Plan::Free,
+        failed_attempts: 0,
+        locked_until: None,
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+#[tokio::test]
+async fn create_duplicate_email_returns_conflict() {
+    let docker = clients::Cli::default();
+    let pg = docker.run(Postgres::default());
+    let port = pg.get_host_port_ipv4(5432);
+
+    let url = format!("postgres://postgres:postgres@127.0.0.1:{}/postgres", port);
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+    sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+
+    let repo = PostgresUserRepository::new(Arc::new(pool));
+
+    repo.create(make_user("dupe@example.com")).await.unwrap();
+    let result = repo.create(make_user("dupe@example.com")).await;
+
+    assert!(
+        matches!(result, Err(AppError::Conflict(_))),
+        "expected Conflict, got {:?}",
+        result
+    );
+}

--- a/api/tests/unit.rs
+++ b/api/tests/unit.rs
@@ -1,6 +1,9 @@
 #[path = "unit/helpers.rs"]
 pub mod helpers;
 
+#[path = "unit/config_test.rs"]
+mod config_test;
+
 #[path = "unit/services/auth_service_test.rs"]
 mod auth_service_test;
 

--- a/api/tests/unit.rs
+++ b/api/tests/unit.rs
@@ -9,3 +9,6 @@ mod auth_service_login_test;
 
 #[path = "unit/services/auth_service_logout_test.rs"]
 mod auth_service_logout_test;
+
+#[path = "unit/services/auth_service_refresh_test.rs"]
+mod auth_service_refresh_test;

--- a/api/tests/unit.rs
+++ b/api/tests/unit.rs
@@ -12,3 +12,6 @@ mod auth_service_logout_test;
 
 #[path = "unit/services/auth_service_refresh_test.rs"]
 mod auth_service_refresh_test;
+
+#[path = "unit/handlers/auth_handler_test.rs"]
+mod auth_handler_test;

--- a/api/tests/unit/config_test.rs
+++ b/api/tests/unit/config_test.rs
@@ -1,0 +1,15 @@
+use done_with_debt_api::config::hours_to_max_age_secs;
+
+#[test]
+fn hours_to_max_age_secs_computes_correctly() {
+    assert_eq!(hours_to_max_age_secs(168), Some(604800));
+    assert_eq!(hours_to_max_age_secs(0), Some(0));
+    assert_eq!(hours_to_max_age_secs(1), Some(3600));
+}
+
+#[test]
+fn hours_to_max_age_secs_returns_none_on_overflow() {
+    // u64::MAX / 3600 = 5124095576030431; one more overflows
+    assert_eq!(hours_to_max_age_secs(u64::MAX / 3600 + 1), None);
+    assert_eq!(hours_to_max_age_secs(u64::MAX), None);
+}

--- a/api/tests/unit/handlers/auth_handler_test.rs
+++ b/api/tests/unit/handlers/auth_handler_test.rs
@@ -347,6 +347,57 @@ async fn refresh_with_no_auth_returns_unauthorized() {
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
 
+// ── Empty cookie value ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn logout_with_empty_cookie_value_returns_unauthorized() {
+    // Cookie: token=  (no value) must be treated as "no token present".
+    let app = make_router(false, "Lax", 168);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/auth/logout")
+                .header("Cookie", "token=")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "empty token= cookie must be treated as unauthenticated"
+    );
+}
+
+// ── SameSite validation ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn cookie_same_site_with_semicolon_injection_returns_500() {
+    // A semicolon in COOKIE_SAME_SITE injects extra cookie attributes.
+    // The server must reject this instead of emitting a malformed Set-Cookie.
+    let app = make_router(false, "Lax; Injected=attribute", 168);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auth/login")
+                .header("Content-Type", "application/json")
+                .body(login_body())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "semicolon-injected SameSite must return 500, not silently produce a malformed cookie"
+    );
+}
+
 // ── Bearer scheme is case-insensitive ────────────────────────────────────────
 
 #[tokio::test]

--- a/api/tests/unit/handlers/auth_handler_test.rs
+++ b/api/tests/unit/handlers/auth_handler_test.rs
@@ -210,3 +210,27 @@ async fn cookie_is_secure_when_same_site_none_even_if_secure_false() {
         "cookie must be Secure when SameSite=None, got: {cookie}"
     );
 }
+
+#[tokio::test]
+async fn invalid_cookie_same_site_returns_500_instead_of_panicking() {
+    // A value with a newline makes HeaderValue::from_str fail.
+    // The handler must return 500 Internal Server Error, not panic.
+    let app = make_router(false, "Lax\r\nInjected: header", 168);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auth/login")
+                .header("Content-Type", "application/json")
+                .body(login_body())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "invalid cookie config must return 500, not panic"
+    );
+}

--- a/api/tests/unit/handlers/auth_handler_test.rs
+++ b/api/tests/unit/handlers/auth_handler_test.rs
@@ -8,7 +8,7 @@ use axum::{
 use tower::util::ServiceExt;
 
 use done_with_debt_api::{
-    adapters::inbound::http::handlers::auth::{login, register, AuthState},
+    adapters::inbound::http::handlers::auth::{login, logout, refresh, register, AuthState},
     domain::ports::inbound::auth_service::{
         AuthResult, AuthServicePort, LoginCommand, LogoutCommand, RefreshCommand, RegisterCommand,
     },
@@ -16,7 +16,7 @@ use done_with_debt_api::{
 };
 
 use async_trait::async_trait;
-use axum::routing::post;
+use axum::routing::{delete, post};
 use uuid::Uuid;
 
 // ── Stub AuthService ──────────────────────────────────────────────────────────
@@ -60,6 +60,8 @@ fn make_router(secure: bool, same_site: &str, expiry_hours: u64) -> Router {
     Router::new()
         .route("/auth/register", post(register))
         .route("/auth/login", post(login))
+        .route("/auth/logout", delete(logout))
+        .route("/auth/refresh", post(refresh))
         .with_state(state)
 }
 
@@ -232,5 +234,140 @@ async fn invalid_cookie_same_site_returns_500_instead_of_panicking() {
         response.status(),
         StatusCode::INTERNAL_SERVER_ERROR,
         "invalid cookie config must return 500, not panic"
+    );
+}
+
+// ── logout coverage ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn logout_with_bearer_token_returns_no_content() {
+    let app = make_router(false, "Lax", 168);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/auth/logout")
+                .header("Authorization", "Bearer test.jwt.token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn logout_with_cookie_returns_no_content() {
+    let app = make_router(false, "Lax", 168);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/auth/logout")
+                .header("Cookie", "token=test.jwt.token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn logout_with_no_auth_returns_unauthorized() {
+    let app = make_router(false, "Lax", 168);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/auth/logout")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+// ── refresh coverage ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn refresh_with_bearer_token_returns_ok() {
+    let app = make_router(false, "Lax", 168);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auth/refresh")
+                .header("Authorization", "Bearer test.jwt.token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn refresh_with_cookie_returns_ok() {
+    let app = make_router(false, "Lax", 168);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auth/refresh")
+                .header("Cookie", "token=test.jwt.token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn refresh_with_no_auth_returns_unauthorized() {
+    let app = make_router(false, "Lax", 168);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auth/refresh")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+// ── Bearer scheme is case-insensitive ────────────────────────────────────────
+
+#[tokio::test]
+async fn bearer_scheme_is_case_insensitive() {
+    // RFC 7235: auth-scheme is case-insensitive. "bearer" must work like "Bearer".
+    let app = make_router(false, "Lax", 168);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/auth/logout")
+                .header("Authorization", "bearer test.jwt.token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::NO_CONTENT,
+        "lowercase 'bearer' scheme must be accepted"
     );
 }

--- a/api/tests/unit/handlers/auth_handler_test.rs
+++ b/api/tests/unit/handlers/auth_handler_test.rs
@@ -1,0 +1,212 @@
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    Router,
+};
+use tower::util::ServiceExt;
+
+use done_with_debt_api::{
+    adapters::inbound::http::handlers::auth::{login, register, AuthState},
+    domain::ports::inbound::auth_service::{
+        AuthResult, AuthServicePort, LoginCommand, LogoutCommand, RefreshCommand, RegisterCommand,
+    },
+    errors::AppError,
+};
+
+use async_trait::async_trait;
+use axum::routing::post;
+use uuid::Uuid;
+
+// ── Stub AuthService ──────────────────────────────────────────────────────────
+
+struct StubAuthService;
+
+#[async_trait]
+impl AuthServicePort for StubAuthService {
+    async fn register(&self, _cmd: RegisterCommand) -> Result<AuthResult, AppError> {
+        Ok(AuthResult {
+            token: "test.jwt.token".to_string(),
+            user_id: Uuid::nil(),
+        })
+    }
+    async fn login(&self, _cmd: LoginCommand) -> Result<AuthResult, AppError> {
+        Ok(AuthResult {
+            token: "test.jwt.token".to_string(),
+            user_id: Uuid::nil(),
+        })
+    }
+    async fn logout(&self, _cmd: LogoutCommand) -> Result<(), AppError> {
+        Ok(())
+    }
+    async fn refresh(&self, _cmd: RefreshCommand) -> Result<AuthResult, AppError> {
+        Ok(AuthResult {
+            token: "test.jwt.token".to_string(),
+            user_id: Uuid::nil(),
+        })
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn make_router(secure: bool, same_site: &str, expiry_hours: u64) -> Router {
+    let state = Arc::new(AuthState {
+        service: Arc::new(StubAuthService),
+        cookie_secure: secure,
+        cookie_same_site: same_site.to_string(),
+        cookie_max_age_secs: expiry_hours * 3600,
+    });
+    Router::new()
+        .route("/auth/register", post(register))
+        .route("/auth/login", post(login))
+        .with_state(state)
+}
+
+fn register_body() -> Body {
+    Body::from(r#"{"email":"john@example.com","password":"password1","full_name":"John Doe"}"#)
+}
+
+fn login_body() -> Body {
+    Body::from(r#"{"email":"john@example.com","password":"password1"}"#)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn register_set_cookie_includes_max_age() {
+    let app = make_router(false, "Lax", 168);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auth/register")
+                .header("Content-Type", "application/json")
+                .body(register_body())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let cookie = response
+        .headers()
+        .get("set-cookie")
+        .expect("Set-Cookie header must be present")
+        .to_str()
+        .unwrap();
+    assert!(
+        cookie.contains("Max-Age=604800"),
+        "cookie should contain Max-Age=604800 (168h), got: {cookie}"
+    );
+}
+
+#[tokio::test]
+async fn login_set_cookie_includes_max_age() {
+    let app = make_router(false, "Lax", 168);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auth/login")
+                .header("Content-Type", "application/json")
+                .body(login_body())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let cookie = response
+        .headers()
+        .get("set-cookie")
+        .expect("Set-Cookie header must be present")
+        .to_str()
+        .unwrap();
+    assert!(
+        cookie.contains("Max-Age=604800"),
+        "cookie should contain Max-Age=604800 (168h), got: {cookie}"
+    );
+}
+
+#[tokio::test]
+async fn cookie_is_not_secure_when_same_site_lax_and_secure_false() {
+    let app = make_router(false, "Lax", 168);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auth/login")
+                .header("Content-Type", "application/json")
+                .body(login_body())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let cookie = response
+        .headers()
+        .get("set-cookie")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(
+        !cookie.contains("Secure"),
+        "cookie must NOT be Secure for SameSite=Lax + secure=false, got: {cookie}"
+    );
+}
+
+#[tokio::test]
+async fn cookie_is_secure_when_cookie_secure_true() {
+    let app = make_router(true, "Lax", 168);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auth/login")
+                .header("Content-Type", "application/json")
+                .body(login_body())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let cookie = response
+        .headers()
+        .get("set-cookie")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(
+        cookie.contains("Secure"),
+        "cookie must be Secure when cookie_secure=true, got: {cookie}"
+    );
+}
+
+#[tokio::test]
+async fn cookie_is_secure_when_same_site_none_even_if_secure_false() {
+    // SameSite=None requires Secure per spec — enforce it regardless of config
+    let app = make_router(false, "None", 168);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auth/login")
+                .header("Content-Type", "application/json")
+                .body(login_body())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let cookie = response
+        .headers()
+        .get("set-cookie")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(
+        cookie.contains("Secure"),
+        "cookie must be Secure when SameSite=None, got: {cookie}"
+    );
+}

--- a/api/tests/unit/helpers.rs
+++ b/api/tests/unit/helpers.rs
@@ -19,4 +19,11 @@ impl AuthTokenRepository for NoopAuthTokenRepository {
     async fn revoke_by_token(&self, _token: &str) -> Result<(), AppError> {
         Ok(())
     }
+    async fn rotate_token(
+        &self,
+        _old_token: &str,
+        new_token: AuthToken,
+    ) -> Result<AuthToken, AppError> {
+        Ok(new_token)
+    }
 }

--- a/api/tests/unit/services/auth_service_logout_test.rs
+++ b/api/tests/unit/services/auth_service_logout_test.rs
@@ -110,7 +110,9 @@ impl AuthTokenRepository for InMemoryAuthTokenRepository {
         new_token: AuthToken,
     ) -> Result<AuthToken, AppError> {
         let mut tokens = self.tokens.lock().unwrap();
-        tokens.remove(old_token);
+        if tokens.remove(old_token).is_none() {
+            return Err(AppError::Unauthorized);
+        }
         tokens.insert(new_token.token.clone(), new_token.clone());
         Ok(new_token)
     }

--- a/api/tests/unit/services/auth_service_logout_test.rs
+++ b/api/tests/unit/services/auth_service_logout_test.rs
@@ -103,6 +103,17 @@ impl AuthTokenRepository for InMemoryAuthTokenRepository {
         }
         Ok(())
     }
+
+    async fn rotate_token(
+        &self,
+        old_token: &str,
+        new_token: AuthToken,
+    ) -> Result<AuthToken, AppError> {
+        let mut tokens = self.tokens.lock().unwrap();
+        tokens.remove(old_token);
+        tokens.insert(new_token.token.clone(), new_token.clone());
+        Ok(new_token)
+    }
 }
 
 // Newtype wrappers for Arc sharing
@@ -118,6 +129,13 @@ impl AuthTokenRepository for SharedTokenRepo {
     }
     async fn revoke_by_token(&self, token: &str) -> Result<(), AppError> {
         self.0.revoke_by_token(token).await
+    }
+    async fn rotate_token(
+        &self,
+        old_token: &str,
+        new_token: AuthToken,
+    ) -> Result<AuthToken, AppError> {
+        self.0.rotate_token(old_token, new_token).await
     }
 }
 

--- a/api/tests/unit/services/auth_service_refresh_test.rs
+++ b/api/tests/unit/services/auth_service_refresh_test.rs
@@ -39,6 +39,12 @@ impl InMemoryAuthTokenRepository {
     fn contains(&self, token: &str) -> bool {
         self.tokens.lock().unwrap().contains_key(token)
     }
+
+    fn tamper_user_id(&self, token: &str, new_user_id: Uuid) {
+        if let Some(entry) = self.tokens.lock().unwrap().get_mut(token) {
+            entry.user_id = new_user_id;
+        }
+    }
 }
 
 #[async_trait]
@@ -59,6 +65,17 @@ impl AuthTokenRepository for InMemoryAuthTokenRepository {
         self.tokens.lock().unwrap().remove(token);
         Ok(())
     }
+
+    async fn rotate_token(
+        &self,
+        old_token: &str,
+        new_token: AuthToken,
+    ) -> Result<AuthToken, AppError> {
+        let mut tokens = self.tokens.lock().unwrap();
+        tokens.remove(old_token);
+        tokens.insert(new_token.token.clone(), new_token.clone());
+        Ok(new_token)
+    }
 }
 
 struct SharedTokenRepo(Arc<InMemoryAuthTokenRepository>);
@@ -73,6 +90,83 @@ impl AuthTokenRepository for SharedTokenRepo {
     }
     async fn revoke_by_token(&self, token: &str) -> Result<(), AppError> {
         self.0.revoke_by_token(token).await
+    }
+    async fn rotate_token(
+        &self,
+        old_token: &str,
+        new_token: AuthToken,
+    ) -> Result<AuthToken, AppError> {
+        self.0.rotate_token(old_token, new_token).await
+    }
+}
+
+// ── Failing-rotate stub ───────────────────────────────────────────────────────
+
+struct FailingRotateTokenRepo {
+    tokens: Mutex<HashMap<String, AuthToken>>,
+}
+
+impl FailingRotateTokenRepo {
+    fn new() -> Self {
+        Self {
+            tokens: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn contains(&self, token: &str) -> bool {
+        self.tokens.lock().unwrap().contains_key(token)
+    }
+}
+
+#[async_trait]
+impl AuthTokenRepository for FailingRotateTokenRepo {
+    async fn create(&self, token: AuthToken) -> Result<AuthToken, AppError> {
+        self.tokens
+            .lock()
+            .unwrap()
+            .insert(token.token.clone(), token.clone());
+        Ok(token)
+    }
+
+    async fn find_by_token(&self, token: &str) -> Result<Option<AuthToken>, AppError> {
+        Ok(self.tokens.lock().unwrap().get(token).cloned())
+    }
+
+    async fn revoke_by_token(&self, token: &str) -> Result<(), AppError> {
+        self.tokens.lock().unwrap().remove(token);
+        Ok(())
+    }
+
+    async fn rotate_token(
+        &self,
+        _old_token: &str,
+        _new_token: AuthToken,
+    ) -> Result<AuthToken, AppError> {
+        Err(AppError::Internal(anyhow::anyhow!(
+            "simulated rotation failure"
+        )))
+    }
+}
+
+struct SharedFailingRepo(Arc<FailingRotateTokenRepo>);
+
+#[async_trait]
+impl AuthTokenRepository for SharedFailingRepo {
+    async fn create(&self, token: AuthToken) -> Result<AuthToken, AppError> {
+        self.0.create(token).await
+    }
+    async fn find_by_token(&self, token: &str) -> Result<Option<AuthToken>, AppError> {
+        self.0.find_by_token(token).await
+    }
+    async fn revoke_by_token(&self, token: &str) -> Result<(), AppError> {
+        self.0.revoke_by_token(token).await
+    }
+    async fn rotate_token(
+        &self,
+        old_token: &str,
+        new_token: AuthToken,
+    ) -> Result<AuthToken, AppError> {
+        self.0.rotate_token(old_token, new_token).await
     }
 }
 
@@ -293,4 +387,60 @@ async fn refresh_with_expired_jwt_returns_unauthorized() {
     let result = service.refresh(RefreshCommand { token: expired }).await;
 
     assert!(matches!(result, Err(AppError::Unauthorized)));
+}
+
+#[tokio::test]
+async fn refresh_with_mismatched_user_id_returns_unauthorized() {
+    // Token in DB has a different user_id than the one encoded in the JWT sub.
+    // The service must detect this inconsistency and return Unauthorized.
+    let (service, token_repo) = make_shared_service(user_with_password("password1"));
+    let token = login(&service).await;
+
+    token_repo.tamper_user_id(&token, Uuid::new_v4());
+
+    let result = service.refresh(RefreshCommand { token }).await;
+
+    assert!(matches!(result, Err(AppError::Unauthorized)));
+}
+
+#[tokio::test]
+async fn refresh_rotation_failure_leaves_old_token_intact() {
+    // If rotate_token fails, the old token must remain active (atomicity guarantee).
+    let user = user_with_password("password1");
+    let inner = Arc::new(FailingRotateTokenRepo::new());
+    let service = AuthService::new(
+        InMemoryUserRepository::with_user(user),
+        SharedFailingRepo(Arc::clone(&inner)),
+        JWT_SECRET.to_string(),
+        168_u64,
+    );
+
+    let old_token = service
+        .login(LoginCommand {
+            email: "john@example.com".to_string(),
+            password: "password1".to_string(),
+        })
+        .await
+        .unwrap()
+        .token;
+
+    assert!(
+        inner.contains(&old_token),
+        "pre-condition: old token must be seeded"
+    );
+
+    let result = service
+        .refresh(RefreshCommand {
+            token: old_token.clone(),
+        })
+        .await;
+
+    assert!(
+        result.is_err(),
+        "refresh must propagate rotate_token failure"
+    );
+    assert!(
+        inner.contains(&old_token),
+        "old token must still be present after failed rotation"
+    );
 }

--- a/api/tests/unit/services/auth_service_refresh_test.rs
+++ b/api/tests/unit/services/auth_service_refresh_test.rs
@@ -1,0 +1,296 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, Utc};
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::Serialize;
+use uuid::Uuid;
+
+use done_with_debt_api::domain::{
+    entities::{
+        auth_token::AuthToken,
+        user::{Plan, User},
+    },
+    ports::{
+        inbound::auth_service::{AuthServicePort, LoginCommand, LogoutCommand, RefreshCommand},
+        outbound::{
+            auth_token_repository::AuthTokenRepository,
+            user_repository::{FailedLoginOutcome, UserRepository},
+        },
+    },
+    services::auth_service::AuthService,
+};
+use done_with_debt_api::errors::AppError;
+
+// ── In-memory token repository ────────────────────────────────────────────────
+
+struct InMemoryAuthTokenRepository {
+    tokens: Mutex<HashMap<String, AuthToken>>,
+}
+
+impl InMemoryAuthTokenRepository {
+    fn new() -> Self {
+        Self {
+            tokens: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn contains(&self, token: &str) -> bool {
+        self.tokens.lock().unwrap().contains_key(token)
+    }
+}
+
+#[async_trait]
+impl AuthTokenRepository for InMemoryAuthTokenRepository {
+    async fn create(&self, token: AuthToken) -> Result<AuthToken, AppError> {
+        self.tokens
+            .lock()
+            .unwrap()
+            .insert(token.token.clone(), token.clone());
+        Ok(token)
+    }
+
+    async fn find_by_token(&self, token: &str) -> Result<Option<AuthToken>, AppError> {
+        Ok(self.tokens.lock().unwrap().get(token).cloned())
+    }
+
+    async fn revoke_by_token(&self, token: &str) -> Result<(), AppError> {
+        self.tokens.lock().unwrap().remove(token);
+        Ok(())
+    }
+}
+
+struct SharedTokenRepo(Arc<InMemoryAuthTokenRepository>);
+
+#[async_trait]
+impl AuthTokenRepository for SharedTokenRepo {
+    async fn create(&self, token: AuthToken) -> Result<AuthToken, AppError> {
+        self.0.create(token).await
+    }
+    async fn find_by_token(&self, token: &str) -> Result<Option<AuthToken>, AppError> {
+        self.0.find_by_token(token).await
+    }
+    async fn revoke_by_token(&self, token: &str) -> Result<(), AppError> {
+        self.0.revoke_by_token(token).await
+    }
+}
+
+// ── In-memory user repository ─────────────────────────────────────────────────
+
+struct InMemoryUserRepository {
+    users: Mutex<HashMap<String, User>>,
+}
+
+impl InMemoryUserRepository {
+    fn with_user(user: User) -> Self {
+        let mut map = HashMap::new();
+        map.insert(user.email.clone(), user);
+        Self {
+            users: Mutex::new(map),
+        }
+    }
+}
+
+#[async_trait]
+impl UserRepository for InMemoryUserRepository {
+    async fn find_by_email(&self, email: &str) -> Result<Option<User>, AppError> {
+        Ok(self.users.lock().unwrap().get(email).cloned())
+    }
+    async fn create(&self, user: User) -> Result<User, AppError> {
+        Ok(user)
+    }
+    async fn record_failed_attempt(
+        &self,
+        _user_id: Uuid,
+        _max_attempts: i32,
+        _lock_until: DateTime<Utc>,
+    ) -> Result<FailedLoginOutcome, AppError> {
+        Ok(FailedLoginOutcome::Incremented { attempts: 1 })
+    }
+    async fn reset_failed_attempts(&self, _user_id: Uuid) -> Result<(), AppError> {
+        Ok(())
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const JWT_SECRET: &str = "test_secret_key_32_chars_minimum!";
+
+fn user_with_password(password: &str) -> User {
+    use argon2::{
+        password_hash::{rand_core::OsRng, SaltString},
+        Argon2, PasswordHasher,
+    };
+    let salt = SaltString::generate(&mut OsRng);
+    let hash = Argon2::default()
+        .hash_password(password.as_bytes(), &salt)
+        .unwrap()
+        .to_string();
+    User {
+        id: Uuid::new_v4(),
+        email: "john@example.com".to_string(),
+        password_hash: Some(hash),
+        full_name: "John Doe".to_string(),
+        avatar_url: None,
+        email_verified_at: None,
+        plan: Plan::Free,
+        failed_attempts: 0,
+        locked_until: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
+
+fn make_shared_service(
+    user: User,
+) -> (
+    AuthService<InMemoryUserRepository, SharedTokenRepo>,
+    Arc<InMemoryAuthTokenRepository>,
+) {
+    let token_repo = Arc::new(InMemoryAuthTokenRepository::new());
+    let service = AuthService::new(
+        InMemoryUserRepository::with_user(user),
+        SharedTokenRepo(Arc::clone(&token_repo)),
+        JWT_SECRET.to_string(),
+        168_u64,
+    );
+    (service, token_repo)
+}
+
+fn expired_jwt(user_id: Uuid) -> String {
+    #[derive(Serialize)]
+    struct Claims {
+        jti: String,
+        sub: String,
+        exp: usize,
+    }
+    let claims = Claims {
+        jti: Uuid::new_v4().to_string(),
+        sub: user_id.to_string(),
+        exp: (Utc::now() - Duration::hours(1)).timestamp() as usize,
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(JWT_SECRET.as_bytes()),
+    )
+    .unwrap()
+}
+
+async fn login(service: &AuthService<InMemoryUserRepository, SharedTokenRepo>) -> String {
+    service
+        .login(LoginCommand {
+            email: "john@example.com".to_string(),
+            password: "password1".to_string(),
+        })
+        .await
+        .unwrap()
+        .token
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn refresh_with_valid_token_returns_new_token() {
+    let (service, _) = make_shared_service(user_with_password("password1"));
+    let token = login(&service).await;
+
+    let result = service.refresh(RefreshCommand { token }).await;
+
+    assert!(result.is_ok(), "expected Ok, got {:?}", result);
+    let auth = result.unwrap();
+    assert!(!auth.token.is_empty());
+    assert!(auth.user_id != Uuid::nil());
+}
+
+#[tokio::test]
+async fn refreshed_token_is_different_from_original() {
+    let (service, _) = make_shared_service(user_with_password("password1"));
+    let original = login(&service).await;
+
+    let result = service
+        .refresh(RefreshCommand {
+            token: original.clone(),
+        })
+        .await
+        .unwrap();
+
+    assert_ne!(result.token, original);
+}
+
+#[tokio::test]
+async fn refresh_revokes_old_token() {
+    let (service, token_repo) = make_shared_service(user_with_password("password1"));
+    let old_token = login(&service).await;
+
+    let _ = service
+        .refresh(RefreshCommand {
+            token: old_token.clone(),
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        !token_repo.contains(&old_token),
+        "old token should be revoked after refresh"
+    );
+}
+
+#[tokio::test]
+async fn refresh_persists_new_token() {
+    let (service, token_repo) = make_shared_service(user_with_password("password1"));
+    let old_token = login(&service).await;
+
+    let new_auth = service
+        .refresh(RefreshCommand {
+            token: old_token.clone(),
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        token_repo.contains(&new_auth.token),
+        "new token should be persisted after refresh"
+    );
+}
+
+#[tokio::test]
+async fn refresh_with_revoked_token_returns_unauthorized() {
+    let (service, _) = make_shared_service(user_with_password("password1"));
+    let token = login(&service).await;
+
+    service
+        .logout(LogoutCommand {
+            token: token.clone(),
+        })
+        .await
+        .unwrap();
+
+    let result = service.refresh(RefreshCommand { token }).await;
+
+    assert!(matches!(result, Err(AppError::Unauthorized)));
+}
+
+#[tokio::test]
+async fn refresh_with_invalid_jwt_returns_unauthorized() {
+    let (service, _) = make_shared_service(user_with_password("password1"));
+
+    let result = service
+        .refresh(RefreshCommand {
+            token: "not.a.valid.jwt".to_string(),
+        })
+        .await;
+
+    assert!(matches!(result, Err(AppError::Unauthorized)));
+}
+
+#[tokio::test]
+async fn refresh_with_expired_jwt_returns_unauthorized() {
+    let (service, _) = make_shared_service(user_with_password("password1"));
+    let expired = expired_jwt(Uuid::new_v4());
+
+    let result = service.refresh(RefreshCommand { token: expired }).await;
+
+    assert!(matches!(result, Err(AppError::Unauthorized)));
+}

--- a/api/tests/unit/services/auth_service_refresh_test.rs
+++ b/api/tests/unit/services/auth_service_refresh_test.rs
@@ -72,7 +72,9 @@ impl AuthTokenRepository for InMemoryAuthTokenRepository {
         new_token: AuthToken,
     ) -> Result<AuthToken, AppError> {
         let mut tokens = self.tokens.lock().unwrap();
-        tokens.remove(old_token);
+        if tokens.remove(old_token).is_none() {
+            return Err(AppError::Unauthorized);
+        }
         tokens.insert(new_token.token.clone(), new_token.clone());
         Ok(new_token)
     }


### PR DESCRIPTION
## Summary
- Implements `POST /auth/refresh` with JWT token rotation — validates signature, checks token is not revoked, issues a new JWT, revokes the old one
- Implements `PostgresUserRepository` and `PostgresAuthTokenRepository` using runtime SQLx queries (no compile-time macros required)
- Implements all auth HTTP handlers (`register`, `login`, `logout`, `refresh`) with httpOnly cookie support for web and `Authorization: Bearer` header support for mobile
- Wires the router with `AuthState` carrying the service and cookie config

## Test plan
- [ ] 7 new unit tests: refresh happy path, token rotation, old token revocation, new token persistence, revoked token rejected, invalid JWT rejected, expired JWT rejected
- [ ] All 24 unit tests pass
- [ ] `cargo clippy` clean, `cargo fmt` applied

Closes #6